### PR TITLE
Fix CLI input argument

### DIFF
--- a/scenedetect/cli.py
+++ b/scenedetect/cli.py
@@ -233,7 +233,7 @@ def get_cli_parser(scene_detectors_list, timecode_formats_list):
 
     parser.add_argument(
         '-i', '--input', metavar = 'VIDEO_FILE',
-        required = True, type = file,
+        required = True, type = argparse.FileType('r'),
         help = '[REQUIRED] Path to input video.')
 
     parser.add_argument(


### PR DESCRIPTION
After my installation I tried to use `scenedetect` command and the compiler rose a Not Defined error at line 236, thats because `file` is not a valid type. After this commit everything worked okay. PS. I am using Python 3.5.