### PR TITLE
Speed improvement / do not decode dropped frames

### DIFF
--- a/scenedetect/__init__.py
+++ b/scenedetect/__init__.py
@@ -210,7 +210,7 @@ def detect_scenes(cap, scene_list, detector_list, stats_writer = None,
     # If start_frame is set, we drop the required number of frames first.
     # (seeking doesn't work very well, if at all, with OpenCV...)
     while (frames_read < start_frame):
-        (rv, im) = cap.read()
+        rv = cap.grab()
         frames_read += 1
 
     stats_file_keys = []
@@ -224,7 +224,7 @@ def detect_scenes(cap, scene_list, detector_list, stats_writer = None,
         # If frameskip is set, we drop the required number of frames first.
         if frame_skip > 0:
             for i in range(frame_skip):
-                (rv, im) = cap.read()
+                rv = cap.grab()
                 if not rv:
                     break
                 frames_read += 1


### PR DESCRIPTION
Scene detection speed can be improved if `frame_skip` is used. 
By now, PySceneDetect advises OpenCV to load, decode and return every frame, even the dropped ones (`VideoCapture::read()`). If `VideoCapture::grab()` is used instead, the dropped frames are only loaded, but never decoded nor converted to a numpy representation. 
This change prevents useless work, making scene detection (much) faster (depending on the values of `frame_skip` and the video's codec). 

For more details, read the [VideoCapture documentation](http://docs.opencv.org/2.4/modules/highgui/doc/reading_and_writing_images_and_video.html#videocapture), in particular `read()`, `grab` and `retrieve`. 