### PR TITLE
Python 2.7 support: Changed FileNotFoundError to OSError

### DIFF
--- a/scenedetect/__init__.py
+++ b/scenedetect/__init__.py
@@ -365,7 +365,7 @@ def split_input_video(input_path, output_path, timecode_list_str):
              '-o', output_path,
              '--split', 'timecodes:%s' % timecode_list_str,
              input_path])
-    except FileNotFoundError:
+    except OSError:
         print('[PySceneDetect] Error: mkvmerge could not be found on the system.'
               ' Please install mkvmerge to enable video output support.')
     if ret_val is not None:


### PR DESCRIPTION
The exception FileNotFoundError is not defined in Python 2.7.
Instead, except the parent exception 'OSError'
https://docs.python.org/3/library/exceptions.html#exception-hierarchy

Signed-off-by: Tal Kain <tal@kain.net>