### PR TITLE
Detector speedups and Divizion by zero fix in cli

### DIFF
--- a/scenedetect/cli/context.py
+++ b/scenedetect/cli/context.py
@@ -294,10 +294,11 @@ class CliContext(object):
             with open(self.scene_list_path, 'wt') as scene_list_file:
                 write_scene_list(scene_list_file, cut_list, scene_list)
         # Handle `list-scenes`.
+        list_length = len(scene_list) if len(scene_list) else 1
         logging.info('Detected %d scenes, average shot length %.1f seconds.',
-                     len(scene_list),
+                     list_length,
                      sum([(end_time - start_time).get_seconds()
-                          for start_time, end_time in scene_list]) / float(len(scene_list)))
+                          for start_time, end_time in scene_list]) / float(list_length))
         if self.print_scene_list:
             logging.info(""" Scene List:
 -----------------------------------------------------------------------

--- a/scenedetect/detectors/threshold_detector.py
+++ b/scenedetect/detectors/threshold_detector.py
@@ -31,6 +31,7 @@ to detect scene cuts when the average frame intensity passes the set threshold.
 """
 
 # Third-Party Library Imports
+import cv2
 import numpy
 
 # PySceneDetect Library Imports
@@ -93,10 +94,7 @@ class ThresholdDetector(SceneDetector):
         Returns:
             Floating point value representing average pixel intensity.
         """
-        num_pixel_values = float(
-            frame.shape[0] * frame.shape[1] * frame.shape[2])
-        avg_pixel_value = numpy.sum(frame[:,:,:]) / num_pixel_values
-        return avg_pixel_value
+        return cv2.mean(cv2.mean(frame)[:3])[0]
 
     def frame_under_threshold(self, frame):
         """Check if the frame is below (true) or above (false) the threshold.


### PR DESCRIPTION
Hi,

I have moved the detector speedups to the new code layout and gains are again visible.

Please note that threshold detector has lost sensitivity, due to recent changes, however outside of current changes. For example, 
running a threshold detection on golden eye yields no scenes found:
```
(py3) lpetrov@ubuntu:~/mnt/projects/github/PySceneDetect (master)*$ python -m scenedetect -d 1 -i goldeneye.mp4 detect-threshold
[PySceneDetect] Loaded 1 video, framerate: 23.98 FPS, resolution: 1280 x 544
[PySceneDetect] Downscale factor set to 1, effective resolution: 1280 x 544
[PySceneDetect] Detecting scenes...
[PySceneDetect] Processed 1980 frames in 5.3 seconds (average 377.08 FPS).
[PySceneDetect] Detected 1 scenes, average shot length 0.0 seconds.

```
On the branch prior my commits (b817dd9), the division by zero occurs (fixed above), since no scenes were found, hence same behavior.

```
(py3) lpetrov@ubuntu:~/mnt/projects/github/PySceneDetect (detached*)*$ python -m scenedetect -d 1 -i goldeneye.mp4 detect-threshold
[PySceneDetect] Loaded 1 video, framerate: 23.98 FPS, resolution: 1280 x 544
[PySceneDetect] Downscale factor set to 1, effective resolution: 1280 x 544
[PySceneDetect] Detecting scenes...
[PySceneDetect] Processed 1980 frames in 5.8 seconds (average 343.35 FPS).
Traceback (most recent call last):
  File "/home/lpetrov/mnt/.virtualenvs/py3/lib/python3.6/site-packages/click/core.py", line 700, in main
    ctx.exit()
  File "/home/lpetrov/mnt/.virtualenvs/py3/lib/python3.6/site-packages/click/core.py", line 484, in exit
    sys.exit(code)
SystemExit: 0

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/lpetrov/mnt/projects/github/PySceneDetect/scenedetect/__main__.py", line 63, in <module>
    main()
  File "/home/lpetrov/mnt/projects/github/PySceneDetect/scenedetect/__main__.py", line 58, in main
    cli.main(obj=cli_ctx)   # Parse CLI arguments with registered callbacks.
  File "/home/lpetrov/mnt/.virtualenvs/py3/lib/python3.6/site-packages/click/core.py", line 700, in main
    ctx.exit()
  File "/home/lpetrov/mnt/.virtualenvs/py3/lib/python3.6/site-packages/click/core.py", line 331, in __exit__
    self.close()
  File "/home/lpetrov/mnt/.virtualenvs/py3/lib/python3.6/site-packages/click/core.py", line 420, in close
    cb()
  File "/home/lpetrov/mnt/projects/github/PySceneDetect/scenedetect/cli/context.py", line 300, in process_input
    for start_time, end_time in scene_list]) / float(len(scene_list)))
ZeroDivisionError: float division by zero

```
Also, I agree with the new layout. It allows for better modularity and I already have a couple detection algorithms in the works.

thanks