### PR TITLE
[FIX] VideoManager read function failed on multiple videos

### DIFF
--- a/scenedetect/video_manager.py
+++ b/scenedetect/video_manager.py
@@ -739,20 +739,18 @@ class VideoManager(object):
         if not self._started:
             raise VideoDecoderNotStarted()
 
-        read_frame = False
         if self._curr_cap is not None and self._end_of_video != True:
-            while not read_frame:
+            read_frame, self._last_frame = self._curr_cap.read()
+
+            # Switch to the next capture when the current one is over
+            if not read_frame and self._get_next_cap():
                 read_frame, self._last_frame = self._curr_cap.read()
-                # Switch to the next capture when the current one is over
-                if not read_frame:
-                    # Break the loop when all the captures are over
-                    if not self._get_next_cap():
-                        break
-                    # Get frame of the new capture
-                    read_frame, self._last_frame = self._curr_cap.read()
-                if self._downscale_factor > 1:
-                    self._last_frame = self._last_frame[
-                        ::self._downscale_factor, ::self._downscale_factor, :]
+
+            # Downscale frame if there was any
+            if read_frame and self._downscale_factor > 1:
+                self._last_frame = self._last_frame[
+                    ::self._downscale_factor, ::self._downscale_factor, :]
+
         if self._end_time is not None and self._curr_time > self._end_time:
             read_frame = False
             self._last_frame = None

--- a/scenedetect/video_manager.py
+++ b/scenedetect/video_manager.py
@@ -743,8 +743,13 @@ class VideoManager(object):
         if self._curr_cap is not None and self._end_of_video != True:
             while not read_frame:
                 read_frame, self._last_frame = self._curr_cap.read()
-                if not read_frame and not self._get_next_cap():
-                    break
+                # Switch to the next capture when the current one is over
+                if not read_frame:
+                    # Break the loop when all the captures are over
+                    if not self._get_next_cap():
+                        break
+                    # Get frame of the new capture
+                    read_frame, self._last_frame = self._curr_cap.read()
                 if self._downscale_factor > 1:
                     self._last_frame = self._last_frame[
                         ::self._downscale_factor, ::self._downscale_factor, :]

--- a/tests/test_video_manager.py
+++ b/tests/test_video_manager.py
@@ -283,11 +283,10 @@ def test_multiple_videos(test_video_file):
         video_manager.release()
 
 def test_many_videos_downscale_detect_scenes(test_video_file):
-    """ Test VideoManager handling decoding frames across video boundaries. """
+    """ Test scene detection on multiple videos in VideoManager. """
 
-    NUM_FRAMES = 10
     NUM_VIDEOS = 3
-    # Open VideoManager and get base timecode.
+    # Open VideoManager with NUM_VIDEOS test videos
     video_manager = VideoManager([test_video_file] * NUM_VIDEOS)
     video_manager.set_downscale_factor()
 

--- a/tests/test_video_manager.py
+++ b/tests/test_video_manager.py
@@ -51,6 +51,7 @@ import os
 import pytest
 import cv2
 
+from scenedetect.scene_manager import SceneManager
 # PySceneDetect Library Imports
 from scenedetect.video_manager import VideoManager
 from scenedetect.video_manager import VideoOpenFailure
@@ -281,3 +282,19 @@ def test_multiple_videos(test_video_file):
         # Will release the VideoManagers in vm_list as well.
         video_manager.release()
 
+def test_many_videos_downscale_detect_scenes(test_video_file):
+    """ Test VideoManager handling decoding frames across video boundaries. """
+
+    NUM_FRAMES = 10
+    NUM_VIDEOS = 3
+    # Open VideoManager and get base timecode.
+    video_manager = VideoManager([test_video_file] * NUM_VIDEOS)
+    video_manager.set_downscale_factor()
+
+    try:
+        video_manager.start()
+        scene_manager = SceneManager()
+        scene_manager.detect_scenes(frame_source=video_manager)
+    finally:
+        # Will release the VideoManagers in vm_list as well.
+        video_manager.release()


### PR DESCRIPTION
**Traceback:**
>"scenedetect/video_manager.py", line 757, in read
>    ::self._downscale_factor, ::self._downscale_factor, :]
>TypeError: 'NoneType' object is not subscriptable

**Reason:**
1. Initializing a VideoManager object with multiple video paths
2. Set the downscale factor, e.g. with `set_downscale_factor()`
3. Invoke `read()` function of the created VideoManager object, e.g. via passing it to the SceneManager `detect_scenes()` as `frame_source` argument

This happens because of the bug in video_manager.py around lines 750. If one of the captured videos is over, an empty numpy.ndarray is returned on line 745 and its further use leads to the aforementioned error.
The commit contains the bug fix in video_manager.py as well as an integration test (VideoManager + SceneManager) in tests/test_video_manager.py
