### PR TITLE
Support selection of scenes for `save-images` and `split-video`

### DIFF
--- a/scenedetect/cli/context.py
+++ b/scenedetect/cli/context.py
@@ -361,7 +361,7 @@ class CliContext(object):
         ) if self.scenes else None
 
         scene_list = [
-            (s, i in scene_indices)
+            (s, i in scene_indices if scene_indices else True)
             for i, s in enumerate(scene_list)
         ]
 

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -515,7 +515,7 @@ class SceneManager(object):
             self._cutting_list += detector.post_process(frame_num)
 
 
-    def detect_scenes(self, frame_source, end_time=None, frame_skip=0,
+    def detect_scenes(self, frame_source, end_time=None, frame_skip=0, max_scenes=None,
                       show_progress=True):
         # type: (VideoManager, Union[int, FrameTimecode],
         #        Optional[Union[int, FrameTimecode]], Optional[bool]) -> int
@@ -588,6 +588,8 @@ class SceneManager(object):
             while True:
                 if end_frame is not None and curr_frame >= end_frame:
                     break
+                if max_scenes is not None and len(self._get_cutting_list()) >= max_scenes:
+                    break
                 # We don't compensate for frame_skip here as the frame_skip option
                 # is not allowed when using a StatsManager - thus, processing is
                 # *always* required for *all* frames when frame_skip > 0.
@@ -626,4 +628,3 @@ class SceneManager(object):
                 progress_bar.close()
 
         return num_frames
-

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -135,7 +135,7 @@ def write_scene_list(output_csv_file, scene_list, cut_list=None):
         "Start Frame", "Start Timecode", "Start Time (seconds)",
         "End Frame", "End Timecode", "End Time (seconds)",
         "Length (frames)", "Length (timecode)", "Length (seconds)"])
-    for i, (start, end) in enumerate(scene_list):
+    for i, ((start, end), selected) in enumerate(scene_list):
         duration = end - start
         csv_writer.writerow([
             '%d' % (i+1),


### PR DESCRIPTION
Add a new `-r` / `--scene-range` command-line option to `scenedetect`
that allows users to specify the scene indxes they'd like to save images
and/or videos from.  This option should be a comma-separated list of one
or more integers and/or ranges.  Ranges are specified in a syntax
similar to python's list slice notation, e.g. `start:[stop:[step]]`.

Scene detection will stop once the number of scenes to be selected has
been detected.  (If any of the indexes is specified as a negative offset
from the end, then all scenes must be detected, and no such
short-circuiting is possible.)

See #123 for discussion.