### PR TITLE
Travis automated testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: python
+python:
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
+install:
+  - "pip install -r requirements.txt"
+  - "git fetch"
+  - "git checkout origin/resources -- tests/testvideo.mp4"
+script:
+  - python -m pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.8"
 install:
   - "pip install -r requirements.txt"
-  - "git fetch"
-  - "git restore -s origin/resources -- tests/testvideo.mp4"
+  - "git fetch --depth=1 git@github.com:Breakthrough/PySceneDetect.git refs/heads/resources:refs/remotes/origin/resources"
+  - "git checkout refs/remotes/origin/resources -- tests/testvideo.mp4"
 script:
   - python -m pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9"
 install:
   - "pip install -r requirements.txt"
   - "git fetch"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ python:
 install:
   - "pip install -r requirements.txt"
   - "git fetch"
-  - "git checkout origin/resources -- tests/testvideo.mp4"
+  - "git restore -s origin/resources -- tests/testvideo.mp4"
 script:
   - python -m pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.8"
 install:
   - "pip install -r requirements.txt"
-  - "git fetch --depth=1 git@github.com:joshcoales/PySceneDetect.git refs/heads/resources:refs/remotes/origin/resources"
+  - "git fetch --depth=1 https://github.com/Breakthrough/PySceneDetect.git refs/heads/resources:refs/remotes/origin/resources"
   - "git checkout refs/remotes/origin/resources -- tests/testvideo.mp4"
 script:
   - python -m pytest tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
   - "3.8"
 install:
   - "pip install -r requirements.txt"
-  - "git fetch --depth=1 git@github.com:Breakthrough/PySceneDetect.git refs/heads/resources:refs/remotes/origin/resources"
+  - "git fetch --depth=1 git@github.com:joshcoales/PySceneDetect.git refs/heads/resources:refs/remotes/origin/resources"
   - "git checkout refs/remotes/origin/resources -- tests/testvideo.mp4"
 script:
   - python -m pytest tests/

--- a/scenedetect/thirdparty/simpletable.py
+++ b/scenedetect/thirdparty/simpletable.py
@@ -55,6 +55,7 @@ v0.4 2019-05-24 by Walter Schwenger
 import codecs
 
 
+# noinspection PyCompatibility,PyUnresolvedReferences
 def quote(string):
     try:
         from urllib.parse import quote

--- a/scenedetect/thirdparty/simpletable.py
+++ b/scenedetect/thirdparty/simpletable.py
@@ -54,7 +54,15 @@ v0.4 2019-05-24 by Walter Schwenger
 
 import codecs
 
-from urllib.parse import quote
+
+def quote(string):
+    try:
+        from urllib.parse import quote
+        return quote(string)
+    except ModuleNotFoundError:
+        from urllib import pathname2url
+        return pathname2url(string)
+
 
 class SimpleTableCell(object):
     """A table class to create table cells.

--- a/scenedetect/thirdparty/simpletable.py
+++ b/scenedetect/thirdparty/simpletable.py
@@ -140,7 +140,7 @@ class SimpleTableRow(object):
     cell2 = SimpleTableCell('world!')
     row = SimpleTableRow([cell1, cell2])
     """
-    def __init__(self, cells=[], header=False):
+    def __init__(self, cells=None, header=False):
         """Table row constructor.
 
         Keyword arguments:
@@ -150,6 +150,7 @@ class SimpleTableRow(object):
                   responsibility to verify whether it was created with the
                   header flag set to True.
         """
+        cells = cells or []
         if isinstance(cells[0], SimpleTableCell):
             self.cells = cells
         else:
@@ -200,7 +201,7 @@ class SimpleTable(object):
     rows = SimpleTableRow(['Hello,', 'world!'])
     table = SimpleTable(rows)
     """
-    def __init__(self, rows=[], header_row=None, css_class=None):
+    def __init__(self, rows=None, header_row=None, css_class=None):
         """Table constructor.
 
         Keyword arguments:
@@ -211,6 +212,7 @@ class SimpleTable(object):
                       header flag set to True.
         css_class -- table CSS class
         """
+        rows = rows or []
         if isinstance(rows[0], SimpleTableRow):
             self.rows = rows
         else:
@@ -261,7 +263,7 @@ class SimpleTable(object):
 
 class HTMLPage(object):
     """A class to create HTML pages containing CSS and tables."""
-    def __init__(self, tables=[], css=None, encoding="utf-8"):
+    def __init__(self, tables=None, css=None, encoding="utf-8"):
         """HTML page constructor.
 
         Keyword arguments:
@@ -270,7 +272,7 @@ class HTMLPage(object):
                table string
         encoding -- Characters encoding. Default: UTF-8
         """
-        self.tables = tables
+        self.tables = tables or []
         self.css = css
         self.encoding = encoding
         

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -14,11 +14,12 @@ import os
 import scenedetect
 from scenedetect.video_manager import VideoManager
 from scenedetect.scene_manager import SceneManager
-from scenedetect.frame_timecode import FrameTimecode
 from scenedetect.stats_manager import StatsManager
 from scenedetect.detectors import ContentDetector
+from tests.conftest import TEST_VIDEO_FILE
 
 STATS_FILE_PATH = 'api_test_statsfile.csv'
+
 
 def test_api():
 
@@ -30,7 +31,7 @@ def test_api():
     # videos can be appended by simply specifying more file paths in the list
     # passed to the VideoManager constructor. Note that appending multiple videos
     # requires that they all have the same frame size, and optionally, framerate.
-    video_manager = VideoManager(['testvideo.mp4'])
+    video_manager = VideoManager([TEST_VIDEO_FILE])
     stats_manager = StatsManager()
     scene_manager = SceneManager(stats_manager)
     # Add ContentDetector algorithm (constructor takes detector options like threshold).
@@ -78,6 +79,6 @@ def test_api():
     finally:
         video_manager.release()
 
+
 if __name__ == "__main__":
     test_api()
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+# Video file used by test_video_file fixture.
+import os
+
+import pytest
+
+TEST_VIDEO_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)), "testvideo.mp4")
+
+
+@pytest.fixture
+def test_video_file():
+    # type: () -> str
+    """ Fixture for test video file path (ensures file exists).
+
+    Access in test case by adding a test_video_file argument to obtain the path.
+    """
+    print(TEST_VIDEO_FILE)
+    if not os.path.exists(TEST_VIDEO_FILE):
+        raise FileNotFoundError(
+            'Test video file (%s) must be present to run test cases' % TEST_VIDEO_FILE)
+    return TEST_VIDEO_FILE

--- a/tests/test_scene_manager.py
+++ b/tests/test_scene_manager.py
@@ -50,11 +50,7 @@ Alternatively, the TEST_VIDEO_FILE constant can be replaced with any valid video
 # pylint: disable=redefined-outer-name
 
 
-# Standard Library Imports
-import os
-
 # Third-Party Library Imports
-import pytest
 import cv2
 
 # PySceneDetect Library Imports
@@ -62,22 +58,6 @@ from scenedetect.scene_manager import SceneManager
 from scenedetect.frame_timecode import FrameTimecode
 from scenedetect.video_manager import VideoManager
 from scenedetect.detectors import ContentDetector
-
-
-TEST_VIDEO_FILE = 'testvideo.mp4'
-
-
-@pytest.fixture
-def test_video_file():
-    # type: () -> str
-    """ Fixture for test video file path (ensures file exists).
-
-    Access in test case by adding a test_video_file argument to obtain the path.
-    """
-    if not os.path.exists(TEST_VIDEO_FILE):
-        raise FileNotFoundError(
-            'Test video file (%s) must be present to run test cases' % TEST_VIDEO_FILE)
-    return TEST_VIDEO_FILE
 
 
 def test_content_detect(test_video_file):
@@ -156,4 +136,3 @@ def test_scene_list(test_video_file):
 
     finally:
         vm.release()
-

--- a/tests/test_stats_manager.py
+++ b/tests/test_stats_manager.py
@@ -72,29 +72,11 @@ from scenedetect.stats_manager import NoMetricsRegistered
 from scenedetect.stats_manager import NoMetricsSet
 
 
-TEST_VIDEO_FILE = 'testvideo.mp4'
-
 # TODO: Replace TEST_STATS_FILES with a @pytest.fixture called generate_stats_file.
 #       It should generate the path to a random stats file for use in a test case.
 TEST_STATS_FILES = ['TEST_STATS_FILE'] * 4
 TEST_STATS_FILES = ['%s_%012d.csv' % (stats_file, random.randint(0, 10**12))
                     for stats_file in TEST_STATS_FILES]
-
-
-@pytest.fixture
-def test_video_file():
-    # type: () -> str
-    """ Fixture for test video file path (ensures file exists).
-
-    Access in test case by adding a test_video_file argument to obtain the path.
-    """
-    if not os.path.exists(TEST_VIDEO_FILE):
-        raise FileNotFoundError(
-            'Test video file (%s) must be present to run test cases' % TEST_VIDEO_FILE)
-    for stats_file in TEST_STATS_FILES:
-        if os.path.exists(stats_file):
-            raise FileExistsError('Existing file would be overwritten by running test, aborting.')
-    return TEST_VIDEO_FILE
 
 
 def test_metrics():
@@ -339,4 +321,3 @@ def test_load_corrupt_stats(test_video_file):
     finally:
         for stats_file in stats_files: stats_file.close()
         for stats_file in TEST_STATS_FILES: os.remove(stats_file)
-

--- a/tests/test_stats_manager.py
+++ b/tests/test_stats_manager.py
@@ -153,19 +153,16 @@ def test_detector_metrics(test_video_file):
 def test_load_empty_stats(test_video_file):
     """ Test loading an empty stats file, ensuring it results in no errors. """
     try:
-        stats_file = open(TEST_STATS_FILES[0], 'w')
+        open(TEST_STATS_FILES[0], 'w').close()
 
-        stats_file.close()
-        stats_file = open(TEST_STATS_FILES[0], 'r')
+        with open(TEST_STATS_FILES[0], 'r') as stats_file:
 
-        stats_manager = StatsManager()
+            stats_manager = StatsManager()
 
-        stats_reader = get_csv_reader(stats_file)
-        stats_manager.load_from_csv(stats_reader)
+            stats_reader = get_csv_reader(stats_file)
+            stats_manager.load_from_csv(stats_reader)
 
     finally:
-        stats_file.close()
-
         os.remove(TEST_STATS_FILES[0])
 
 

--- a/tests/test_video_manager.py
+++ b/tests/test_video_manager.py
@@ -66,7 +66,8 @@ from scenedetect.video_manager import VideoFramerateUnavailable
 from scenedetect.video_manager import VideoParameterMismatch
 
 
-TEST_VIDEO_FILE = 'testvideo.mp4'       # Video file used by test_video_file fixture.
+# Video file used by test_video_file fixture.
+TEST_VIDEO_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)), "testvideo.mp4")
 
 
 @pytest.fixture

--- a/tests/test_video_manager.py
+++ b/tests/test_video_manager.py
@@ -44,9 +44,6 @@ directly:  https://github.com/Breakthrough/PySceneDetect/tree/resources/tests
 # pylint: disable=redefined-outer-name
 
 
-# Standard Library Imports
-import os
-
 # Third-Party Library Imports
 import pytest
 import cv2
@@ -64,23 +61,6 @@ from scenedetect.video_manager import VideoDecoderNotStarted
 # TODO: The following exceptions still require test cases:
 from scenedetect.video_manager import VideoFramerateUnavailable
 from scenedetect.video_manager import VideoParameterMismatch
-
-
-# Video file used by test_video_file fixture.
-TEST_VIDEO_FILE = os.path.join(os.path.abspath(os.path.dirname(__file__)), "testvideo.mp4")
-
-
-@pytest.fixture
-def test_video_file():
-    # type: () -> str
-    """ Fixture for test video file path (ensures file exists).
-
-    Access in test case by adding a test_video_file argument to obtain the path.
-    """
-    if not os.path.exists(TEST_VIDEO_FILE):
-        raise FileNotFoundError(
-            'Test video file (%s) must be present to run test cases' % TEST_VIDEO_FILE)
-    return TEST_VIDEO_FILE
 
 
 def test_video_params(test_video_file):


### PR DESCRIPTION
Hey, thought it might be handy to automate those tests you've written, so they can be run on PRs and stuff. Initially this was just adding a .travis.yml, but I needed to tweak some tests a bit too.

You can see it running here: https://travis-ci.org/github/joshcoales/PySceneDetect/branches
When you merge this, you can set them up properly here: https://travis-ci.org/github/Breakthrough/PySceneDetect

Notes:
1) The readme says we support python 3.3, but travis no longer supports that, so I've not got that being tested.
2) I changed scenedetect/thirdparty/simpletable.py because it broke python 2.7 support. So now it tries to import the python3 urllib.parse.quote, but failing that, imports python2's equivalent.
3) I fixed a number of uses of empty list default argument in simpletable.py. Do not use mutable default arguments in python: https://docs.python-guide.org/writing/gotchas/
4) I've merged the test_video_file() pytest fixture into a conftest.py file, so that all the test files can use the same one.
5) I've changed the path of the test video, so that it isn't affected by the current working directory.
6) I neatened up test_load_empty_stats() to use context managers