### PR TITLE
Included FRAME_NUMBER macro in docs

### DIFF
--- a/docs/reference/command-line-params.md
+++ b/docs/reference/command-line-params.md
@@ -261,7 +261,7 @@ Options:
                         option -o/--output if set.
   -f, --filename NAME   Filename format, *without* extension, to use when
                         saving image files. You can use the $VIDEO_NAME,
-                        $SCENE_NUMBER, and $IMAGE_NUMBER macros in the file
+                        $SCENE_NUMBER, $IMAGE_NUMBER, and $FRAME_NUMBER macros in the file
                         name. Note that you may have to wrap the format in
                         single quotes.  [default: $VIDEO_NAME-
                         Scene-$SCENE_NUMBER-$IMAGE_NUMBER]

--- a/manual/cli/commands.rst
+++ b/manual/cli/commands.rst
@@ -203,7 +203,7 @@ The `save-images` command takes the following options:
  * ``-f``, ``--filename NAME``
     Filename format, *without* extension, to use when
     saving image files. You can use the $VIDEO_NAME,
-    $SCENE_NUMBER, and $IMAGE_NUMBER macros in the file
+    $SCENE_NUMBER, $IMAGE_NUMBER, and $FRAME_NUMBER macros in the file
     name. Note that you may have to wrap the name using single
     quotes.  [default: $VIDEO_NAME-Scene-$SCENE_NUMBER-$IMAGE_NUMBER]
  * ``-n``, ``--num-images N``

--- a/scenedetect/cli/__init__.py
+++ b/scenedetect/cli/__init__.py
@@ -663,7 +663,7 @@ def split_video_command(ctx, output, filename, high_quality, override_args, quie
     '--filename', '-f', metavar='NAME', default='$VIDEO_NAME-Scene-$SCENE_NUMBER-$IMAGE_NUMBER',
     type=click.STRING, show_default=True, help=
     'Filename format, *without* extension, to use when saving image files. You can use the'
-    ' $VIDEO_NAME, $SCENE_NUMBER, and $IMAGE_NUMBER macros in the file name. Note that you'
+    ' $VIDEO_NAME, $SCENE_NUMBER, $IMAGE_NUMBER, and $FRAME_NUMBER macros in the file name. Note that you'
     ' may have to wrap the format in single quotes.')
 @click.option(
     '--num-images', '-n', metavar='N', default=3,


### PR DESCRIPTION
Added the `$FRAME_NUMBER` macro from the `save-images` command to the docs for reference.