### PR TITLE
Image resizing

### DIFF
--- a/docs/reference/command-line-params.md
+++ b/docs/reference/command-line-params.md
@@ -280,6 +280,23 @@ Options:
                         size. [default: 3]  [0<=x<=9]
   -m, --frame-margin N  Number of frames to ignore at the beginning and end of
                         scenes when saving images [default: 1]
+  -s  --scale S         Optional factor by which saved images are rescaled. A 
+                        scaling factor of 1 would not result in rescaling. A 
+                        value <1 results in a smaller saved image, while a 
+                        value >1 results in an image larger than the original. 
+                        This value is ignored if either the height, -h, or 
+                        width, -w, values are specified.
+  -h  --height H        Optional value for the height of the saved images. 
+                        Specifying both the height and width, -w, will resize 
+                        images to an exact size, regardless of aspect ratio. 
+                        Specifying only height will rescale the image to that 
+                        number of pixels in height while preserving the aspect 
+                        ratio.
+  -w  --width W         Optional value for the width of the saved images. 
+                        Specifying both the width and height, -h, will resize 
+                        images to an exact size, regardless of aspect ratio. 
+                        Specifying only width will rescale the image to that 
+                        number of pixels wide while preserving the aspect ratio.
 ```
 
 

--- a/manual/cli/commands.rst
+++ b/manual/cli/commands.rst
@@ -228,6 +228,26 @@ The `save-images` command takes the following options:
  * ``-m``, ``--frame-margin N``
     Number of frames to ignore at the beginning and end of
     scenes when saving images  [default: 1]
+ * ``s``, ``--scale S``
+    Optional factor by which saved images are rescaled. A 
+    scaling factor of 1 would not result in rescaling. A 
+    value <1 results in a smaller saved image, while a 
+    value >1 results in an image larger than the original. 
+    This value is ignored if either the height, -h, or 
+    width, -w, values are specified.
+ * ``h``, ``--height H``
+    Optional value for the height of the saved images. 
+    Specifying both the height and width, -w, will resize 
+    images to an exact size, regardless of aspect ratio. 
+    Specifying only height will rescale the image to that 
+    number of pixels in height while preserving the aspect 
+    ratio.
+ * ``w``, ``--width W``
+    Optional value for the width of the saved images. 
+    Specifying both the width and height, -h, will resize 
+    images to an exact size, regardless of aspect ratio. 
+    Specifying only width will rescale the image to that 
+    number of pixels wide while preserving the aspect ratio.
 
 
 =======================================================================

--- a/scenedetect/cli/__init__.py
+++ b/scenedetect/cli/__init__.py
@@ -698,16 +698,37 @@ def split_video_command(ctx, output, filename, high_quality, override_args, quie
     '-m', '--frame-margin', metavar='N', default=1, show_default=True,
     type=click.INT, help=
     'Number of frames to ignore at the beginning and end of scenes when saving images')
+@click.option(
+    '--scale', '-s', metavar='S', default=None, show_default=False,
+    type=click.FLOAT, help=
+    'Optional factor by which saved images are rescaled. A scaling factor of 1 would'
+    ' not result in rescaling. A value <1 results in a smaller saved image, while a'
+    ' value >1 results in an image larger than the original. This value is ignored if'
+    ' either the height, -h, or width, -w, values are specified.')
+@click.option(
+    '--height', '-h', metavar='H', default=None, show_default=False,
+    type=click.INT, help=
+    'Optional value for the height of the saved images. Specifying both the height'
+    ' and width, -w, will resize images to an exact size, regardless of aspect ratio.'
+    ' Specifying only height will rescale the image to that number of pixels in height'
+    ' while preserving the aspect ratio.')
+@click.option(
+    '--width', '-w', metavar='W', default=None, show_default=False,
+    type=click.INT, help=
+    'Optional value for the width of the saved images. Specifying both the width'
+    ' and height, -h, will resize images to an exact size, regardless of aspect ratio.'
+    ' Specifying only width will rescale the image to that number of pixels wide'
+    ' while preserving the aspect ratio.')
 @click.pass_context
 def save_images_command(ctx, output, filename, num_images, jpeg, webp, quality, png,
-                        compression, frame_margin):
+                        compression, frame_margin, scale, height, width):
     """ Create images for each detected scene. """
     if ctx.obj.save_images:
         duplicate_command(ctx, 'save-images')
     if quality is None:
         quality = 100 if webp else 95
     ctx.obj.save_images_command(num_images, output, filename, jpeg, webp, quality, png,
-                                compression, frame_margin)
+                                compression, frame_margin, scale, height, width)
 
 
 

--- a/scenedetect/cli/context.py
+++ b/scenedetect/cli/context.py
@@ -157,6 +157,9 @@ class CliContext(object):
             '$VIDEO_NAME-Scene-$SCENE_NUMBER-$IMAGE_NUMBER')
         self.num_images = 3                     # save-images -n/--num-images
         self.frame_margin = 1                   # save-images -m/--frame-margin
+        self.scale = None                       # save-images -s/--scale
+        self.height = None                      # save-images -h/--height
+        self.width = None                       # save-images -w/--width
 
         # Properties for split-video command.
         self.split_video = False                # split-video command
@@ -349,7 +352,10 @@ class CliContext(object):
                 encoder_param=self.image_param,
                 image_name_template=self.image_name_format,
                 output_dir=image_output_dir,
-                show_progress=not self.quiet_mode)
+                show_progress=not self.quiet_mode,
+                scale=self.scale,
+                height=self.height,
+                width=self.width)
 
         # Handle export-html command.
         if self.export_html:
@@ -616,8 +622,8 @@ class CliContext(object):
 
 
     def save_images_command(self, num_images, output, name_format, jpeg, webp, quality,
-                            png, compression, frame_margin):
-        # type: (int, str, str, bool, bool, int, bool, int) -> None
+                            png, compression, frame_margin, scale, height, width):
+        # type: (int, str, str, bool, bool, int, bool, int, float, int, int) -> None
         """ Save Images Command: Parses all options/arguments passed to the save-images command,
         or with respect to the CLI, this function processes [save-images options] when calling:
         scenedetect [global options] save-images [save-images options] [other commands...].
@@ -659,6 +665,9 @@ class CliContext(object):
             self.image_name_format = name_format
             self.num_images = num_images
             self.frame_margin = frame_margin
+            self.scale = scale
+            self.height = height
+            self.width = width
 
             image_type = 'JPEG' if self.image_extension == 'jpg' else self.image_extension.upper()
             image_param_type = ''


### PR DESCRIPTION
Implemented saved image resizing per #160. A quick summary of how it is implemented:

- Added a scaling option, `-s` or `--scale`, to the `save-images` command that simply scales the saved images by some number while preserving aspect ratio. Values <1 result in smaller images, while values >1 result in larger images. This value, if specified, is ignored if either of the next two values are also specified.
- Added a height option, `-h` or `--height`, to the `save-images` command that saves the output images at the specified number of pixels tall. If no width is specified (see next bullet), then the width is scaled to preserve the aspect ratio. If the width is specified, then both the height and width are absolute and the aspect ratio is not necessarily preserved.
- Added a width option, `-w` or `--width`, to the `save-images` command that works the same way as the height parameter above.
- For this first pass I simply used `interpolation=cv2.INTER_CUBIC` to do the resizing. From some reading, this works pretty well for scaling up, but for scaling down it might be better to do `cv2.INTER_AREA`.
- The actual resizing happens in the `scene_manager.save_images` function
- I also tried to update help strings and documentation. Let me know if there is anywhere I missed.