### PR TITLE
Don't seek in VideoManager start() unless required

### DIFF
--- a/scenedetect/video_manager.py
+++ b/scenedetect/video_manager.py
@@ -603,7 +603,8 @@ class VideoManager(object):
 
         self._started = True
         self._get_next_cap()
-        self.seek(self._start_time)
+        if self._start_time != 0:
+            self.seek(self._start_time)
 
 
     def seek(self, timecode):


### PR DESCRIPTION
Seeking the video by using cv2's `CAP_PROP_POS_FRAMES` property is not guaranteed to be accurate, and has caused issues for me numerous times. One such example is trying to seek to a certain frame within a video resulted from the concatenation of several transport stream files, when the first video is small (eg. 1.ts - 5 frames, 2.ts - 500 frames -> seeking to frame 0, 1, 2, 3, or 4 would in fact seek to frame 5 - which corresponds to frame 0 from 2.ts and thus entirely skip all the frames in 1.ts).

In my case, seeking is simply not necessary, and not doing it ensures the whole video is processed, so I suggest simply not seeking the video if the start timecode is 0.

However, to really fix this, a new way to seek is necessary. If using OpenCV, simply calling `VideoCapture.read()` (`grab()` might work too, and would definitely be faster) until the desired frame number is reached should work. This would however be slower than setting the `CAP_PROP_POS_FRAMES` property, so maybe making accurate seeking optional (via a parameter to `seek()` or the `VideoManager` itself perhaps?) would work best.

For now though, simply not seeking at all when the start timecode is 0 would be an improvement, at least in my situation.