### PR TITLE
fix: FrameTimeCode approximation flooring instead of rounding

### DIFF
--- a/scenedetect/frame_timecode.py
+++ b/scenedetect/frame_timecode.py
@@ -233,7 +233,7 @@ class FrameTimecode(object):
             Integer number of frames the passed number of seconds represents using
             the current FrameTimecode's framerate property.
         """
-        return int(seconds * self.framerate)
+        return round(seconds * self.framerate)
 
 
     def _parse_timecode_number(self, timecode):
@@ -304,7 +304,7 @@ class FrameTimecode(object):
             if not (hrs >= 0 and mins >= 0 and secs >= 0 and mins < 60 and secs < 60):
                 raise ValueError('Invalid timecode range (values outside allowed range).')
             secs += (((hrs * 60.0) + mins) * 60.0)
-            return int(secs * self.framerate)
+            return self._seconds_to_frames(secs)
 
 
     def __iadd__(self, other):

--- a/tests/test_frame_timecode.py
+++ b/tests/test_frame_timecode.py
@@ -239,3 +239,11 @@ def test_subtraction():
 
     with pytest.raises(TypeError): FrameTimecode('00:00:02.000', fps=20.0) == x - 10
 
+@pytest.mark.parametrize("frame_num,fps", [(1, 1), (61, 14), (29, 25), (126, 24000/1001)])
+def test_identity(frame_num, fps):
+    ''' Test FrameTimecode values, when used in init return the same values '''
+    frame_time_code = FrameTimecode(frame_num, fps=fps)
+    assert FrameTimecode(frame_time_code) == frame_time_code
+    assert FrameTimecode(frame_time_code.get_frames(), fps=fps) == frame_time_code
+    assert FrameTimecode(frame_time_code.get_seconds(), fps=fps) == frame_time_code
+    assert FrameTimecode(frame_time_code.get_timecode(), fps=fps) == frame_time_code


### PR DESCRIPTION
Suggested solution to https://github.com/Breakthrough/PySceneDetect/issues/268 .