### PR TITLE
Capitalize image size flags to avoid name conflict

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,13 @@ matrix:
       python: "3.10"
 
 install:
-  # `setuptools` is pinned for the Python 3.7 builder to work correctly.
+  # TODO: `setuptools` is pinned for the Python 3.7 builder and can be unpinned when removed.
   - "python -m pip install --upgrade pip build wheel virtualenv setuptools==62.3.4"
   # Make sure we get latest binary packages of the video input libraries.
-  # TODO(#292): Add a Python 3.11 builder once newer versions of the `av` package are supported. 
-  - "python -m pip install av==9.2 opencv-python-headless --only-binary :all:"
+  # TODO(#292): Add a Python 3.11 builder once newer versions of the `av` package are supported.
+  # TODO: `opencv-python-headless` is pinned for the xenial build. Unpin `opencv-python-headless`
+  # when https://github.com/opencv/opencv/issues/23090 is resolved.
+  - "python -m pip install av==9.2 opencv-python-headless==4.6.0.66 --only-binary :all:"
   # Install other required packages and download required test resources.
   - "python -m pip install -r requirements_headless.txt"
   - "git fetch --depth=1 https://github.com/Breakthrough/PySceneDetect.git refs/heads/resources:refs/remotes/origin/resources"
@@ -46,9 +48,6 @@ script:
   - python -m pytest tests/
   # TODO: Install ffmpeg/mkvtoolnix to run split-video tests.
 
-  # Remove optional dependencies before performing CLI tests
-  - python -m pip uninstall -y av
-
   #
   # Test CLI using source code
   #
@@ -57,10 +56,9 @@ script:
   - python -m scenedetect version
   - python -m scenedetect -i tests/resources/testvideo.mp4 -b opencv detect-content time -e 2s
   # Test with optional backends
-  - "python -m pip install -r requirements_headless.txt --only-binary :all:"
   - python -m scenedetect -i tests/resources/testvideo.mp4 -b pyav detect-content time -e 2s
   # Cleanup
-  - python -m pip uninstall -y scenedetect av
+  - python -m pip uninstall -y scenedetect
 
   # Test CLI using source distribution
   - python -m pip install dist/scenedetect-$PACKAGE_VERSION.tar.gz
@@ -68,10 +66,9 @@ script:
   - scenedetect version
   - scenedetect -i tests/resources/testvideo.mp4 -b opencv detect-content time -e 2s
   # Test with optional backends
-  - "python -m pip install -r requirements_headless.txt --only-binary :all:"
   - scenedetect -i tests/resources/testvideo.mp4 -b pyav detect-content time -e 2s
   # Cleanup
-  - python -m pip uninstall -y scenedetect av
+  - python -m pip uninstall -y scenedetect
 
   # Test CLI using binary wheel
   - python -m pip install dist/scenedetect-$PACKAGE_VERSION-py3-none-any.whl
@@ -79,7 +76,6 @@ script:
   - scenedetect version
   - scenedetect -i tests/resources/testvideo.mp4 -b opencv detect-content time -e 2s
   # Test with optional backends
-  - "python -m pip install -r requirements_headless.txt --only-binary :all:"
   - scenedetect -i tests/resources/testvideo.mp4 -b pyav detect-content time -e 2s
   # Cleanup
-  - python -m pip uninstall -y scenedetect av
+  - python -m pip uninstall -y scenedetect

--- a/manual/cli/commands.rst
+++ b/manual/cli/commands.rst
@@ -242,14 +242,14 @@ Command Options
                         width, -w, values are specified.
 
   -H, --height H        Optional value for the height of the saved images.
-                        Specifying both the height and width, -w, will resize
+                        Specifying both the height and width, -W, will resize
                         images to an exact size, regardless of aspect ratio.
                         Specifying only height will rescale the image to that
                         number of pixels in height while preserving the aspect
                         ratio.
 
   -W, --width W         Optional value for the width of the saved images.
-                        Specifying both the width and height, -h, will resize
+                        Specifying both the width and height, -H, will resize
                         images to an exact size, regardless of aspect ratio.
                         Specifying only width will rescale the image to that
                         number of pixels wide while preserving the aspect

--- a/manual/cli/commands.rst
+++ b/manual/cli/commands.rst
@@ -241,14 +241,14 @@ Command Options
                         This value is ignored if either the height, -h, or
                         width, -w, values are specified.
 
-  -h, --height H        Optional value for the height of the saved images.
+  -H, --height H        Optional value for the height of the saved images.
                         Specifying both the height and width, -w, will resize
                         images to an exact size, regardless of aspect ratio.
                         Specifying only height will rescale the image to that
                         number of pixels in height while preserving the aspect
                         ratio.
 
-  -w, --width W         Optional value for the width of the saved images.
+  -W, --width W         Optional value for the width of the saved images.
                         Specifying both the width and height, -h, will resize
                         images to an exact size, regardless of aspect ratio.
                         Specifying only width will rescale the image to that

--- a/scenedetect/cli/__init__.py
+++ b/scenedetect/cli/__init__.py
@@ -1039,7 +1039,7 @@ def split_video_command(
 )
 @click.option(
     '--height',
-    '-h',
+    '-H',
     metavar='H',
     default=None,
     type=click.INT,
@@ -1051,7 +1051,7 @@ def split_video_command(
 )
 @click.option(
     '--width',
-    '-w',
+    '-W',
     metavar='W',
     default=None,
     type=click.INT,


### PR DESCRIPTION
Addresses the name collision identified in #312.

I changed the width and height flags for the image size to be capitalized `-W` and `-H` respectively. The `--width` and `--height` remain unchanged.