### PR TITLE
[docs] Fix typos

### DIFF
--- a/dist/windows/LICENSE-PYTHON
+++ b/dist/windows/LICENSE-PYTHON
@@ -414,7 +414,7 @@ bzip2/libbzip2 version 1.0.6 of 6 September 2010
  * The implementation was written so as to conform with Netscapes SSL.
  *
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are aheared to.  The following conditions
+ * the following conditions are adhered to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -439,7 +439,7 @@ bzip2/libbzip2 version 1.0.6 of 6 September 2010
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the rouines from the library
+ *    The word 'cryptographic' can be left out if the routines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
@@ -457,7 +457,7 @@ bzip2/libbzip2 version 1.0.6 of 6 September 2010
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * The licence and distribution terms for any publically available version or
+ * The licence and distribution terms for any publicly available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]

--- a/dist/windows/LICENSE-PYTHON
+++ b/dist/windows/LICENSE-PYTHON
@@ -414,7 +414,7 @@ bzip2/libbzip2 version 1.0.6 of 6 September 2010
  * The implementation was written so as to conform with Netscapes SSL.
  *
  * This library is free for commercial and non-commercial use as long as
- * the following conditions are adhered to.  The following conditions
+ * the following conditions are aheared to.  The following conditions
  * apply to all code found in this distribution, be it the RC4, RSA,
  * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
  * included with this distribution is covered by the same copyright terms
@@ -439,7 +439,7 @@ bzip2/libbzip2 version 1.0.6 of 6 September 2010
  *    must display the following acknowledgement:
  *    "This product includes cryptographic software written by
  *     Eric Young (eay@cryptsoft.com)"
- *    The word 'cryptographic' can be left out if the routines from the library
+ *    The word 'cryptographic' can be left out if the rouines from the library
  *    being used are not cryptographic related :-).
  * 4. If you include any Windows specific code (or a derivative thereof) from
  *    the apps directory (application code) you must include an acknowledgement:
@@ -457,7 +457,7 @@ bzip2/libbzip2 version 1.0.6 of 6 September 2010
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  *
- * The licence and distribution terms for any publicly available version or
+ * The licence and distribution terms for any publically available version or
  * derivative of this code cannot be changed.  i.e. this code cannot simply be
  * copied and put under another distribution licence
  * [including the GNU Public Licence.]

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -50,7 +50,7 @@ Options
 
 .. option:: -o DIR, --output DIR
 
-  Output directory for created files. If unset, working directory will be used. May be overriden by command options.
+  Output directory for created files. If unset, working directory will be used. May be overridden by command options.
 
 .. option:: -c FILE, --config FILE
 

--- a/scenedetect/_cli/__init__.py
+++ b/scenedetect/_cli/__init__.py
@@ -172,7 +172,7 @@ def _print_command_help(ctx: click.Context, command: click.Command):
     required=False,
     metavar='DIR',
     type=click.Path(exists=False, dir_okay=True, writable=True, resolve_path=True),
-    help='Output directory for created files. If unset, working directory will be used. May be overriden by command options.%s'
+    help='Output directory for created files. If unset, working directory will be used. May be overridden by command options.%s'
     % (USER_CONFIG.get_help_string("global", "output", show_default=False)),
 )
 @click.option(

--- a/scenedetect/_scene_loader.py
+++ b/scenedetect/_scene_loader.py
@@ -94,7 +94,7 @@ class SceneLoader(SceneDetector):
             frame_num:  Frame number of frame that is being passed.
             frame_img:  Decoded frame image (numpy.ndarray) to perform scene detection on. This is
                 unused for this detector as the video is not analyzed, but is allowed for
-                compatiblity.
+                compatibility.
 
         Returns:
             cut_list:   List of cuts (as provided by input csv file)

--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -274,7 +274,7 @@ def get_ffmpeg_version() -> Optional[str]:
     ffmpeg_path = get_ffmpeg_path()
     if ffmpeg_path is None:
         return None
-    # If get_ffmpeg_path() returns a value, the path it returns should be invokable.
+    # If get_ffmpeg_path() returns a value, the path it returns should be invocable.
     output = subprocess.check_output(args=[ffmpeg_path, '-version'], text=True)
     output_split = output.split()
     if len(output_split) >= 3 and output_split[1] == 'version':

--- a/scenedetect/scene_detector.py
+++ b/scenedetect/scene_detector.py
@@ -115,7 +115,7 @@ class SceneDetector:
 
 
 class SparseSceneDetector(SceneDetector):
-    """Base class to inheret from when implementing a sparse scene detection algorithm.
+    """Base class to inherit from when implementing a sparse scene detection algorithm.
 
     This class will be removed in v1.0 and should not be used.
 

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -141,7 +141,7 @@ def compute_downscale_factor(frame_width: int, effective_width: int = DEFAULT_MI
         effective_width: Desired minimum width in pixels.
 
     Returns:
-        int: The defalt downscale factor to use to achieve at least the target effective_width.
+        int: The default downscale factor to use to achieve at least the target effective_width.
     """
     assert not (frame_width < 1 or effective_width < 1)
     if frame_width < effective_width:

--- a/website/pages/changelog.md
+++ b/website/pages/changelog.md
@@ -68,7 +68,7 @@ Includes [MoviePy support](https://github.com/Zulko/moviepy), edge detection cap
     - Edge differences are typically larger than other components, so you may need to increase `-t`/`--threshold` higher when increasing the edge weight (the last component) with `detect-content, for example:
     `detect-content -w 1.0 0.5 1.0 0.25 -t 32`
     - May be enabled by default in the future once it has been more thoroughly tested, further improvements for `detect-content` are being investigated as well (e.g. motion compensation, flash suppression)
-   - Short-form of `detect-content` option `--frame-window` has been changed from `-w` to `-f` to accomodate this change
+   - Short-form of `detect-content` option `--frame-window` has been changed from `-w` to `-f` to accommodate this change
  - [enhancement] Progress bar now displays number of detections while processing, no longer conflicts with log message output
  - [enhancement] When using ffmpeg to split videos, `-map 0` has been added to the default arguments so other audio tracks are also included when present ([#271](https://github.com/Breakthrough/PySceneDetect/issues/271))
  - [enhancement] Add `-a` flag to `version` command to print more information about versions of dependencies/tools being used
@@ -278,7 +278,7 @@ Both the Windows installer and portable distributions now include signed executa
  * [api] Support for live video stream callbacks by adding new `callback` argument to the `detect_scenes()` method of `SceneManager` ([#5](https://github.com/Breakthrough/PySceneDetect/issues/5), thanks @mhashim6)
  * [bugfix] Fix unhandled exception causing improper error message when a video fails to load on non-Windows platforms ([#192](https://github.com/Breakthrough/PySceneDetect/issues/192))
  * [enhancement] Enabled dynamic resizing for progress bar ([#193](https://github.com/Breakthrough/PySceneDetect/issues/193))
- * [enhancement] Always ouptut version number via logger to assist with debugging ([#171](https://github.com/Breakthrough/PySceneDetect/issues/171))
+ * [enhancement] Always output version number via logger to assist with debugging ([#171](https://github.com/Breakthrough/PySceneDetect/issues/171))
  * [bugfix] Resolve RuntimeWarning when running as module ([#181](https://github.com/Breakthrough/PySceneDetect/issues/181))
  * [api] Add `save_images()` function to `scenedetect.scene_manager` module which exposes the same functionality as the CLI `save-images` command ([#88](https://github.com/Breakthrough/PySceneDetect/issues/88))
  * [api] Removed `close_captures()` and `release_captures()` functions from `scenedetect.video_manager` module
@@ -322,7 +322,7 @@ Both the Windows installer and portable distributions now include signed executa
 
  * Resolved long-standing bug where `split-video` command would duplicate certain frames at the beginning/end of the output ([#93](https://github.com/Breakthrough/PySceneDetect/issues/93))
  * This was determined to be caused by copying (instead of re-encoding) the audio track, causing extra frames to be brought in when the audio samples did not line up on a frame boundary (thank you @joshcoales for your assistance)
- * Default behavior is to now re-encode audio tracks using the `aac` codec when using `split-video` (it can be overriden in both the command line and Python interface)
+ * Default behavior is to now re-encode audio tracks using the `aac` codec when using `split-video` (it can be overridden in both the command line and Python interface)
  * Improved timestamp accuracy when using `split-video` command to further reduce instances of duplicated or off-by-one frame issues
  * Fixed application crash when using the `-l`/`--logfile` argument
 

--- a/website/pages/cli.md
+++ b/website/pages/cli.md
@@ -79,7 +79,7 @@ PySceneDetect can look for fades in/out using `detect-threshold` (comparing each
 
 Each mode has slightly different parameters, and is described in detail below. Most detector parameters can also be [set with a config file](http://scenedetect.com/projects/Manual/en/latest/cli/config_file.html).
 
-In general, use `detect-threshold` mode if you want to detect scene boundaries using fades/cuts in/out to black.  If the video uses a lot of fast cuts between content, and has no well-defined scene boundaries, you should use the `detect-adaptive` or  `detect-content` modes.  Once you know what detection mode to use, you can try the parameters recommended below, or generate a statistics file (using the `-s` / `--stats` flag) in order to determine the correct paramters - specifically, the proper threshold value.
+In general, use `detect-threshold` mode if you want to detect scene boundaries using fades/cuts in/out to black.  If the video uses a lot of fast cuts between content, and has no well-defined scene boundaries, you should use the `detect-adaptive` or  `detect-content` modes.  Once you know what detection mode to use, you can try the parameters recommended below, or generate a statistics file (using the `-s` / `--stats` flag) in order to determine the correct parameters - specifically, the proper threshold value.
 
 
 ### Content-Aware Detection
@@ -140,7 +140,7 @@ Coming soon: If more are specified via the `-n` flag, they will start from `00` 
 
 The following arguments are global program options, and need to be applied before any commands (e.g. `detect-content`, `list-scenes`).  They can be used to achieve performance gains for some source material with a variable loss of accuracy.
 
-Assuming the input video is of a high enough resolution, a significant performance gain can be achieved by sub-sampling (down-scaling) the input image by a specific integer factor (2x, 3x, 4x, 5x...).  This is applied automatically to some degree based on the input video size, but can be overriden manually with the `-d` / `--downscale` option.
+Assuming the input video is of a high enough resolution, a significant performance gain can be achieved by sub-sampling (down-scaling) the input image by a specific integer factor (2x, 3x, 4x, 5x...).  This is applied automatically to some degree based on the input video size, but can be overridden manually with the `-d` / `--downscale` option.
 
 This factor represents how many pixels are "skipped" in both the x- and y- directions, effectively down-scaling the image (using nearest-neighbor sampling) by the factor specified (the new resolution being `W/factor x H/factor` if the old resolution is `W x H`).
 

--- a/website/pages/features.md
+++ b/website/pages/features.md
@@ -55,7 +55,7 @@ Future version roadmaps are now [tracked as milestones (link)](https://github.co
 The following features are under consideration for future releases. Any contributions towards completing these features are most welcome (pull requests may be accpeted via Github).
 
  - graphical interface (GUI)
- - automatic threshold detection for the current scene detection methods (or just ouptut message indicating "Predicted Threshold: X")
+ - automatic threshold detection for the current scene detection methods (or just output message indicating "Predicted Threshold: X")
  - suppression of short-length flashes/bursts of light [#35](https://github.com/Breakthrough/PySceneDetect/issues/35)
  - histogram-based detection algorithm in HSV/HSL color space [#53](https://github.com/Breakthrough/PySceneDetect/issues/53)
  - [perceptual hash](https://en.wikipedia.org/wiki/Perceptual_hashing) based scene detection ([prototype by @wjs018 in PR#290](https://github.com/Breakthrough/PySceneDetect/pull/290))

--- a/website/pages/literature.md
+++ b/website/pages/literature.md
@@ -19,9 +19,9 @@ PySceneDetect is a useful tool for statistical analysis of video.  Below are lin
 
  - [Story Understanding in Video Advertisements](https://arxiv.org/pdf/1807.11122) by Keren Ye, Kyle Buettner, Adriana Kovashka (2018)
 
-This list is only provided for academic and research purposes, and is far from an exhaustive source of the uses of PySceneDetect in literature.  If you think a particular submission is relevant and should be added to this list, feel free to [raise an issue](https://github.com/Breakthrough/PySceneDetect/issues/new/choose) with your suggestion.  Publically available material is preferred, although not a requirement.
+This list is only provided for academic and research purposes, and is far from an exhaustive source of the uses of PySceneDetect in literature.  If you think a particular submission is relevant and should be added to this list, feel free to [raise an issue](https://github.com/Breakthrough/PySceneDetect/issues/new/choose) with your suggestion.  Publicly available material is preferred, although not a requirement.
 
 
 # Scene Detection Methodology
 
-You can find the source code for each scene detector in [the scenedetect/detectors folder](https://github.com/Breakthrough/PySceneDetect/tree/main/scenedetect/detectors).  Also see [Issue #62: Reference of paper for the methods used](https://github.com/Breakthrough/PySceneDetect/issues/62) on Github for a futher discussion on detection methodologies.  You are more than welcome to propose any new ideas on the [issue tracker](https://github.com/Breakthrough/PySceneDetect/issues), or share a proof of concept using the Python API by creating a pull request.
+You can find the source code for each scene detector in [the scenedetect/detectors folder](https://github.com/Breakthrough/PySceneDetect/tree/main/scenedetect/detectors).  Also see [Issue #62: Reference of paper for the methods used](https://github.com/Breakthrough/PySceneDetect/issues/62) on Github for a further discussion on detection methodologies.  You are more than welcome to propose any new ideas on the [issue tracker](https://github.com/Breakthrough/PySceneDetect/issues), or share a proof of concept using the Python API by creating a pull request.


### PR DESCRIPTION
Found via `codespell -S *.aip,*.enc -L datas,bu,te`