### PR TITLE
[detectors] Fix not compensating for filter buffer length

### DIFF
--- a/scenedetect/detectors/content_detector.py
+++ b/scenedetect/detectors/content_detector.py
@@ -234,3 +234,7 @@ class ContentDetector(SceneDetector):
         # camera movement. Note that very large kernel sizes can negatively affect accuracy.
         edges = cv2.Canny(lum, low, high)
         return cv2.dilate(edges, self._kernel)
+
+    @property
+    def event_buffer_length(self) -> int:
+        return self._flash_filter.max_behind

--- a/scenedetect/scene_detector.py
+++ b/scenedetect/scene_detector.py
@@ -172,7 +172,12 @@ class FlashFilter:
         self._last_above = None  # Last frame above threshold.
         self._merge_enabled = False  # Used to disable merging until at least one cut was found.
         self._merge_triggered = False  # True when the merge filter is active.
-        self._merge_start = None  # Frame number where we started the merge filte.
+        self._merge_start = None  # Frame number where we started the merge filter.
+
+    @property
+    def max_behind(self) -> int:
+        """Maximum number of frames a filtered cut can be behind the current frame."""
+        return 0 if self._mode == FlashFilter.Mode.SUPPRESS else self._filter_length
 
     def filter(self, frame_num: int, above_threshold: bool) -> ty.List[int]:
         if not self._filter_length > 0:

--- a/website/pages/changelog.md
+++ b/website/pages/changelog.md
@@ -589,4 +589,5 @@ Development
 ## PySceneDetect 0.6.5 (TBD)
 
  - [bugfix] Fix new detectors not working with `default-detector` config option
- - [bugfix] Fix SyntaxWarning due to incorrect escaping [#400](https://github.com/Breakthrough/PySceneDetect/issues/400)
+ - [bugfix] Fix `SyntaxWarning` due to incorrect escaping [#400](https://github.com/Breakthrough/PySceneDetect/issues/400)
+ - [bugfix] Fix `ContentDetector` crash when using callbacks [#416](https://github.com/Breakthrough/PySceneDetect/issues/416)


### PR DESCRIPTION
With the new flash filter, cuts may be placed behind the current frame.

This is similar to AdaptiveDetector, but when the new filter was landed, the max look behind property of the detector wasn't updated. Fixes #416.