### PR TITLE
Standardize min scene length message across detectors

### DIFF
--- a/scenedetect/detectors/adaptive_detector.py
+++ b/scenedetect/detectors/adaptive_detector.py
@@ -50,7 +50,8 @@ class AdaptiveDetector(ContentDetector):
         Arguments:
             adaptive_threshold: Threshold (float) that score ratio must exceed to trigger a
                 new scene (see frame metric adaptive_ratio in stats file).
-            min_scene_len: Minimum length of any scene.
+            min_scene_len: Once a cut is detected, this many frames must pass before a new one can
+                be added to the scene list. Can be an int or FrameTimecode type.
             window_width: Size of window (number of frames) before and after each frame to
                 average together in order to detect deviations from the mean. Must be at least 1.
             min_content_val: Minimum threshold (float) that the content_val must exceed in order to

--- a/scenedetect/detectors/content_detector.py
+++ b/scenedetect/detectors/content_detector.py
@@ -113,7 +113,7 @@ class ContentDetector(SceneDetector):
         Arguments:
             threshold: Threshold the average change in pixel intensity must exceed to trigger a cut.
             min_scene_len: Once a cut is detected, this many frames must pass before a new one can
-                be added to the scene list.
+                be added to the scene list. Can be an int or FrameTimecode type.
             weights: Weight to place on each component when calculating frame score
                 (`content_val` in a statsfile, the value `threshold` is compared against).
             luma_only: If True, only considers changes in the luminance channel of the video.

--- a/scenedetect/detectors/hash_detector.py
+++ b/scenedetect/detectors/hash_detector.py
@@ -57,7 +57,8 @@ class HashDetector(SceneDetector):
         size: Size of square of low frequency data to use for the DCT
         lowpass:  How much high frequency information to filter from the DCT. A value of 2 means
             keep lower 1/2 of the frequency data, 4 means only keep 1/4, etc...
-        min_scene_len: Minimum length of any given scene, in frames (int) or FrameTimecode
+        min_scene_len: Once a cut is detected, this many frames must pass before a new one can
+                be added to the scene list. Can be an int or FrameTimecode type.
     """
 
     def __init__(

--- a/scenedetect/detectors/histogram_detector.py
+++ b/scenedetect/detectors/histogram_detector.py
@@ -38,7 +38,8 @@ class HistogramDetector(SceneDetector):
                 YUV, and normalized based on the number of bins. Higher dicfferences imply greater
                 change in content, so larger threshold values are less sensitive to cuts.
             bins: Number of bins to use for the histogram.
-            min_scene_len:  Minimum length of any scene.
+            min_scene_len:   Once a cut is detected, this many frames must pass before a new one can
+                be added to the scene list. Can be an int or FrameTimecode type.
         """
         super().__init__()
         # Internally, threshold represents the correlation between two histograms and has values

--- a/scenedetect/detectors/threshold_detector.py
+++ b/scenedetect/detectors/threshold_detector.py
@@ -82,8 +82,8 @@ class ThresholdDetector(SceneDetector):
         Arguments:
             threshold:  8-bit intensity value that each pixel value (R, G, and B)
                 must be <= to in order to trigger a fade in/out.
-            min_scene_len:  FrameTimecode object or integer greater than 0 of the
-                minimum length, in frames, of a scene (or subsequent scene cut).
+            min_scene_len:   Once a cut is detected, this many frames must pass before a new one can
+                be added to the scene list. Can be an int or FrameTimecode type.
             fade_bias:  Float between -1.0 and +1.0 representing the percentage of
                 timecode skew for the start of a scene (-1.0 causing a cut at the
                 fade-to-black, 0.0 in the middle, and +1.0 causing the cut to be


### PR DESCRIPTION
I found the min_scene_length docs to be a little confusing for the AdaptiveDetector class, I think it's helpful to know 1) the value is in frames and 2) scenes won't be filtered out / dropped, instead they are merged