### PR TITLE
[export-html] Add new `--show` flag, remove dependency on `save-images`

### DIFF
--- a/scenedetect.cfg
+++ b/scenedetect.cfg
@@ -240,6 +240,9 @@
 # Filename format of created HTML file. Can use $VIDEO_NAME in the name.
 #filename = $VIDEO_NAME-Scenes.html
 
+# Automatically open resulting HTML when processing is complete.
+#show = no
+
 # Override <img> element width/height.
 #image-height = 0
 #image-width = 0

--- a/scenedetect/_cli/__init__.py
+++ b/scenedetect/_cli/__init__.py
@@ -980,6 +980,14 @@ def load_scenes_command(
     help="Height in pixels of the images in the resulting HTML table.%s"
     % (USER_CONFIG.get_help_string("export-html", "image-height", show_default=False)),
 )
+@click.option(
+    "--show",
+    "-s",
+    is_flag=True,
+    flag_value=True,
+    help="Automatically open resulting HTML when processing is complete.%s"
+    % (USER_CONFIG.get_help_string("export-html", "show")),
+)
 @click.pass_context
 def export_html_command(
     ctx: click.Context,
@@ -987,6 +995,7 @@ def export_html_command(
     no_images: bool,
     image_width: ty.Optional[int],
     image_height: ty.Optional[int],
+    show: bool,
 ):
     """Export scene list to HTML file. Requires save-images unless --no-images is specified."""
     ctx = ctx.obj
@@ -1001,6 +1010,7 @@ def export_html_command(
         "html_name_format": ctx.config.get_value("export-html", "filename", filename),
         "image_width": ctx.config.get_value("export-html", "image-width", image_width),
         "image_height": ctx.config.get_value("export-html", "image-height", image_height),
+        "show": ctx.config.get_value("export-html", "show", show),
     }
     ctx.add_command(cli_commands.export_html, export_html_args)
 

--- a/scenedetect/_cli/commands.py
+++ b/scenedetect/_cli/commands.py
@@ -17,6 +17,7 @@ current command-line context, as well as the processing result (scenes and cuts)
 
 import logging
 import typing as ty
+import webbrowser
 from string import Template
 
 from scenedetect._cli.context import CliContext
@@ -43,6 +44,7 @@ def export_html(
     image_width: int,
     image_height: int,
     html_name_format: str,
+    show: bool,
 ):
     """Handles the `export-html` command."""
     (image_filenames, output_dir) = (
@@ -62,6 +64,8 @@ def export_html(
         image_width=image_width,
         image_height=image_height,
     )
+    if show:
+        webbrowser.open(html_path)
 
 
 def list_scenes(

--- a/scenedetect/_cli/commands.py
+++ b/scenedetect/_cli/commands.py
@@ -44,6 +44,7 @@ def export_html(
     image_width: int,
     image_height: int,
     html_name_format: str,
+    include_images: bool,
     show: bool,
 ):
     """Handles the `export-html` command."""
@@ -52,6 +53,7 @@ def export_html(
         if context.save_images_result is not None
         else (None, context.output_dir)
     )
+
     html_filename = Template(html_name_format).safe_substitute(VIDEO_NAME=context.video_stream.name)
     if not html_filename.lower().endswith(".html"):
         html_filename += ".html"
@@ -60,7 +62,7 @@ def export_html(
         output_html_filename=html_path,
         scene_list=scenes,
         cut_list=cuts,
-        image_filenames=image_filenames,
+        image_filenames=image_filenames if include_images else None,
         image_width=image_width,
         image_height=image_height,
     )

--- a/scenedetect/_cli/config.py
+++ b/scenedetect/_cli/config.py
@@ -300,6 +300,7 @@ CONFIG_MAP: ConfigDict = {
         "image-height": 0,
         "image-width": 0,
         "no-images": False,
+        "show": False,
     },
     "list-scenes": {
         "cut-format": "timecode",

--- a/website/pages/changelog.md
+++ b/website/pages/changelog.md
@@ -588,3 +588,6 @@ Development
  - [bugfix] Fix `ContentDetector` crash when using callbacks [#416](https://github.com/Breakthrough/PySceneDetect/issues/416) [#420](https://github.com/Breakthrough/PySceneDetect/issues/420)
  - [general] Timecodes of the form `MM:SS[.nnn]` are now processed correctly [#443](https://github.com/Breakthrough/PySceneDetect/issues/443)
  - [api] The `save_to_csv` function now works correctly with paths from the `pathlib` module
+ - [feature] Add new `--show` flag to `export-html` command to launch browser after processing (#442)
+ - [improvement] The `export-html` command now implicitly invokes `save-images` with default parameters
+     - The output of the `export-html` command will always use the result of the `save-images` command that *precedes* it


### PR DESCRIPTION
Add new `--show` option to display the result of `export-html` automatically in the browser when processing is complete. Remove requirement to explicitly specify `save-images`.

`export-html` will now always use the preceding `save-images` output for the images, unless `--no-images` is specified.  If there is no explicit `save-images` command, it will be run with the default config values (e.g. those from the user config file).