### PR TITLE
Repace _compute_frame_average with numpy.mean

### DIFF
--- a/scenedetect/detectors/threshold_detector.py
+++ b/scenedetect/detectors/threshold_detector.py
@@ -25,32 +25,6 @@ from scenedetect.scene_detector import SceneDetector
 
 logger = getLogger("pyscenedetect")
 
-##
-## ThresholdDetector Helper Functions
-##
-
-
-def _compute_frame_average(frame: numpy.ndarray) -> float:
-    """Computes the average pixel value/intensity for all pixels in a frame.
-
-    The value is computed by adding up the 8-bit R, G, and B values for
-    each pixel, and dividing by the number of pixels multiplied by 3.
-
-    Arguments:
-        frame: Frame representing the RGB pixels to average.
-
-    Returns:
-        Average pixel intensity across all 3 channels of `frame`
-    """
-    num_pixel_values = float(frame.shape[0] * frame.shape[1] * frame.shape[2])
-    avg_pixel_value = numpy.sum(frame[:, :, :]) / num_pixel_values
-    return avg_pixel_value
-
-
-##
-## ThresholdDetector Class Implementation
-##
-
 
 class ThresholdDetector(SceneDetector):
     """Detects fast cuts/slow fades in from and out to a given threshold level.
@@ -150,7 +124,7 @@ class ThresholdDetector(SceneDetector):
         ):
             frame_avg = self.stats_manager.get_metrics(frame_num, self._metric_keys)[0]
         else:
-            frame_avg = _compute_frame_average(frame_img)
+            frame_avg = numpy.mean(frame_img)
             if self.stats_manager is not None:
                 self.stats_manager.set_metrics(frame_num, {self._metric_keys[0]: frame_avg})
 


### PR DESCRIPTION
Discussed in #64. I found that _compute_frame_average and numpy.mean outputs the same scores (averaging frame's pixels). Using numpy.mean can simplify the code, so I created this PR. As reported below, the speed is same between two methods.

### _compute_frame_average
```
awkrail@awkrail:~/oss/PySceneDetect$ time scenedetect -i tmp/goldeneye.mp4 detect-threshold list-scenes
[PySceneDetect] PySceneDetect 0.6.5.2
[PySceneDetect] Detecting scenes...
  Detected: 0 | Progress: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1980/1980 [00:01<00:00, 1780.30frames/s]
[PySceneDetect] Processed 1980 frames in 1.1 seconds (average 1774.85 FPS).
[PySceneDetect] Detected 1 scenes, average shot length 82.6 seconds.
[PySceneDetect] Writing scene list to CSV file:
  goldeneye-Scenes.csv
[PySceneDetect] Scene List:
-----------------------------------------------------------------------
 | Scene # | Start Frame |  Start Time  |  End Frame  |   End Time   |
-----------------------------------------------------------------------
 |      1  |           1 | 00:00:00.000 |        1980 | 00:01:22.582 |
-----------------------------------------------------------------------

real    0m1.368s
user    0m4.619s
sys     0m1.495s
```

### numpy.mean
```
awkrail@awkrail:~/oss/PySceneDetect$ time scenedetect -i tmp/goldeneye.mp4 detect-threshold list-scenes
[PySceneDetect] PySceneDetect 0.6.5.2
[PySceneDetect] Detecting scenes...
  Detected: 0 | Progress: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1980/1980 [00:01<00:00, 1780.21frames/s]
[PySceneDetect] Processed 1980 frames in 1.1 seconds (average 1763.84 FPS).
[PySceneDetect] Detected 1 scenes, average shot length 82.6 seconds.
[PySceneDetect] Writing scene list to CSV file:
  goldeneye-Scenes.csv
[PySceneDetect] Scene List:
-----------------------------------------------------------------------
 | Scene # | Start Frame |  Start Time  |  End Frame  |   End Time   |
-----------------------------------------------------------------------
 |      1  |           1 | 00:00:00.000 |        1980 | 00:01:22.582 |
-----------------------------------------------------------------------

real    0m1.369s
user    0m4.471s
sys     0m1.629s
```