### PR TITLE
[detectors] Add downscale performance hit #401

### DIFF
--- a/benchmark/__main__.py
+++ b/benchmark/__main__.py
@@ -1,6 +1,6 @@
 import argparse
-import time
 import os
+import time
 
 from tqdm import tqdm
 

--- a/scenedetect/detectors/hash_detector.py
+++ b/scenedetect/detectors/hash_detector.py
@@ -179,3 +179,7 @@ class HashDetector(SceneDetector):
         hash_img = dct_low_freq > med
 
         return hash_img
+
+    @property
+    def downscale_performance_hint(self) -> bool:
+        return False

--- a/scenedetect/scene_detector.py
+++ b/scenedetect/scene_detector.py
@@ -131,6 +131,11 @@ class SceneDetector:
         """
         return 0
 
+    @property
+    def downscale_performance_hint(self) -> bool:
+        """Indicates if the detector's performance is improved by downscaling."""
+        return True
+
 
 # TODO(v0.7): Remove this early, no point in keeping it around.
 class SparseSceneDetector(SceneDetector):

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -1283,7 +1283,9 @@ class SceneManager:
                 1 + min(max_y, frame_height) - min_y,
             )
         # Calculate downscale factor and log effective resolution.
-        if self.auto_downscale:
+        if self.auto_downscale and all(
+            detector.downscale_performance_hint for detector in self._detector_list
+        ):
             downscale_factor = compute_downscale_factor(max(effective_frame_size))
         else:
             downscale_factor = self.downscale


### PR DESCRIPTION
Adds a new performance hint property to detectors to indicate if they have a significant performance benefit when using a downscaled version of the frame with minimal accuracy loss.

Disable downscaling if set to `auto` for `HashDetector` (`detect-hash`) as it internally resizes the image to a specific size already.