### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ See [the documentation](https://www.scenedetect.com/docs/latest/api.html) for mo
 
 **Benchmark**:
 
-We evaluate the performance of different detectors in terms of accuracy and processing speed. See the [benchmark report](benchmarks/README.md) for details.
+We evaluate the performance of different detectors in terms of accuracy and processing speed. See the [benchmark report](benchmark/README.md) for details.
 
 ## Reference
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmarking PySceneDetect
 This repository benchmarks the performance of PySceneDetect in terms of both latency and accuracy.
-We evaluate it using the standard dataset for video shot detection: [BBC](https://zenodo.org/records/14865504).
+We evaluate it using the standard dataset for video shot detection: [BBC](https://zenodo.org/records/14865504) and [AutoShot](https://drive.google.com/file/d/17diRkLlNUUjHDooXdqFUTXYje2-x4Yt6/view?usp=sharing).
 
 ## Dataset Download
 ### BBC


### PR DESCRIPTION
The link to the benchmark directory is broken due to changing the directory name. In addition, I added AutoShot URL to benchmarks/readme.md.