### PR TITLE
Import numpy in platform.py

### DIFF
--- a/scenedetect/platform.py
+++ b/scenedetect/platform.py
@@ -27,6 +27,7 @@ import sys
 import typing as ty
 
 import cv2
+import numpy
 
 ##
 ## tqdm Library


### PR DESCRIPTION
Import NumPy before OpenCV in platform.py to prevent import/segfault issues (FreeBSD & cross-platform safety)

On FreeBSD, importing OpenCV (cv2) before NumPy can blow up with errors like “numpy.core.multiarray failed to import” or even a segfault. The reason is that OpenCV relies on NumPy under the hood, so if NumPy hasn’t been loaded yet, things can go wrong.

FreeBSD Ports Tree already carries a patch that imports numpy to prevent this. Thought it would not be a bad idea to upstream this

https://github.com/freebsd/freebsd-ports/blob/main/multimedia/py-scenedetect/files/patch-scenedetect_platform.py