### PR TITLE
Add --expand flag to split-video (#115)

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -857,6 +857,10 @@ Options
 
   Split video using mkvmerge. Faster than re-encoding, but less precise. If set, options other than :option:`-f/--filename <-f>`, :option:`-q/--quiet <-q>` and :option:`-o/--output <-o>` will be ignored. Note that mkvmerge automatically appends the $SCENE_NUMBER suffix.
 
+.. option:: --expand
+
+  Extend the first/last output clips to cover the full input video, even if the :ref:`time <command-time>` command's ``--start``/``--end`` limited the analysis window. Useful for keeping content outside the analyzed region attached to the adjacent split.
+
 
 .. _command-time:
 

--- a/scenedetect.cfg
+++ b/scenedetect.cfg
@@ -206,6 +206,11 @@
 # Arguments to specify to ffmpeg for encoding. Quotes are not required.
 #args = -map 0:v:0 -map 0:a? -map 0:s? -c:v libx264 -preset veryfast -crf 22 -c:a aac
 
+# Extend the first/last output clips to cover the full input video, even if
+# `time -s/-e` limited the analysis window. Useful for keeping content outside
+# the analyzed region attached to the adjacent split.
+#expand = no
+
 
 [save-images]
 # Folder to output videos. Overrides [global] output option.

--- a/scenedetect/_cli/__init__.py
+++ b/scenedetect/_cli/__init__.py
@@ -1295,12 +1295,12 @@ Customized filenames:
     ),
 )
 @click.option(
-    "--expand-to-video",
+    "--expand",
     is_flag=True,
     flag_value=True,
     default=False,
     help="Extend the first/last output clips to cover the full input video, even if `time -s/-e` limited the analysis window. Useful for keeping content outside the analyzed region attached to the adjacent split.{}".format(
-        USER_CONFIG.get_help_string("split-video", "expand-to-video")
+        USER_CONFIG.get_help_string("split-video", "expand")
     ),
 )
 @click.pass_context
@@ -1315,7 +1315,7 @@ def split_video_command(
     preset: str | None,
     args: str | None,
     mkvmerge: bool,
-    expand_to_video: bool,
+    expand: bool,
 ):
     ctx = ctx.obj
     assert isinstance(ctx, CliContext)
@@ -1382,7 +1382,7 @@ def split_video_command(
         "output": ctx.config.get_value("split-video", "output", output),
         "show_output": not ctx.config.get_value("split-video", "quiet", quiet),
         "ffmpeg_args": args,
-        "expand_to_video": ctx.config.get_value("split-video", "expand-to-video", expand_to_video),
+        "expand": ctx.config.get_value("split-video", "expand", expand),
     }
     ctx.add_command(cli_commands.split_video, split_video_args)
 

--- a/scenedetect/_cli/__init__.py
+++ b/scenedetect/_cli/__init__.py
@@ -1294,6 +1294,15 @@ Customized filenames:
         USER_CONFIG.get_help_string("split-video", "mkvmerge")
     ),
 )
+@click.option(
+    "--expand-to-video",
+    is_flag=True,
+    flag_value=True,
+    default=False,
+    help="Extend the first/last output clips to cover the full input video, even if `time -s/-e` limited the analysis window. Useful for keeping content outside the analyzed region attached to the adjacent split.{}".format(
+        USER_CONFIG.get_help_string("split-video", "expand-to-video")
+    ),
+)
 @click.pass_context
 def split_video_command(
     ctx: click.Context,
@@ -1306,6 +1315,7 @@ def split_video_command(
     preset: str | None,
     args: str | None,
     mkvmerge: bool,
+    expand_to_video: bool,
 ):
     ctx = ctx.obj
     assert isinstance(ctx, CliContext)
@@ -1372,6 +1382,7 @@ def split_video_command(
         "output": ctx.config.get_value("split-video", "output", output),
         "show_output": not ctx.config.get_value("split-video", "quiet", quiet),
         "ffmpeg_args": args,
+        "expand_to_video": ctx.config.get_value("split-video", "expand-to-video", expand_to_video),
     }
     ctx.add_command(cli_commands.split_video, split_video_args)
 

--- a/scenedetect/_cli/commands.py
+++ b/scenedetect/_cli/commands.py
@@ -217,16 +217,16 @@ def split_video(
     output: str,
     show_output: bool,
     ffmpeg_args: str,
-    expand_to_video: bool,
+    expand: bool,
 ):
     """Handles the `split-video` command."""
     del cuts  # split-video only uses scenes.
     assert context.video_stream is not None
 
-    if expand_to_video and scenes:
+    if expand and scenes:
         video_duration = context.video_stream.duration
         if video_duration is None:
-            logger.warning("Cannot expand-to-video: video duration is unavailable for this stream.")
+            logger.warning("Cannot --expand: video duration is unavailable for this stream.")
         else:
             scenes = expand_scenes_to_bounds(
                 scenes,

--- a/scenedetect/_cli/commands.py
+++ b/scenedetect/_cli/commands.py
@@ -37,6 +37,7 @@ from scenedetect.scene_manager import (
     CutList,
     Interpolation,
     SceneList,
+    expand_scenes_to_bounds,
 )
 
 logger = logging.getLogger("pyscenedetect")
@@ -216,10 +217,22 @@ def split_video(
     output: str,
     show_output: bool,
     ffmpeg_args: str,
+    expand_to_video: bool,
 ):
     """Handles the `split-video` command."""
     del cuts  # split-video only uses scenes.
     assert context.video_stream is not None
+
+    if expand_to_video and scenes:
+        video_duration = context.video_stream.duration
+        if video_duration is None:
+            logger.warning("Cannot expand-to-video: video duration is unavailable for this stream.")
+        else:
+            scenes = expand_scenes_to_bounds(
+                scenes,
+                start=context.video_stream.base_timecode,
+                end=video_duration,
+            )
 
     if use_mkvmerge:
         name_format = name_format.removesuffix("-$SCENE_NUMBER")

--- a/scenedetect/_cli/config.py
+++ b/scenedetect/_cli/config.py
@@ -468,7 +468,7 @@ CONFIG_MAP: ConfigDict = {
     "split-video": {
         "args": _DEFAULT_FFMPEG_ARGS,
         "copy": False,
-        "expand-to-video": False,
+        "expand": False,
         "filename": "$VIDEO_NAME-Scene-$SCENE_NUMBER",
         "high-quality": False,
         "mkvmerge": False,

--- a/scenedetect/_cli/config.py
+++ b/scenedetect/_cli/config.py
@@ -468,6 +468,7 @@ CONFIG_MAP: ConfigDict = {
     "split-video": {
         "args": _DEFAULT_FFMPEG_ARGS,
         "copy": False,
+        "expand-to-video": False,
         "filename": "$VIDEO_NAME-Scene-$SCENE_NUMBER",
         "high-quality": False,
         "mkvmerge": False,

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -142,8 +142,8 @@ def compute_downscale_factor(frame_width: int, effective_width: int = DEFAULT_MI
 
 def expand_scenes_to_bounds(
     scenes: SceneList,
-    start: int | FrameTimecode,
-    end: int | FrameTimecode,
+    start: FrameTimecode,
+    end: FrameTimecode,
 ) -> SceneList:
     """Return a new scene list whose first scene starts at `start` and last scene ends at `end`.
 

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -140,6 +140,34 @@ def compute_downscale_factor(frame_width: int, effective_width: int = DEFAULT_MI
     return frame_width / float(effective_width)
 
 
+def expand_scenes_to_bounds(
+    scenes: SceneList,
+    start: int | FrameTimecode,
+    end: int | FrameTimecode,
+) -> SceneList:
+    """Return a new scene list whose first scene starts at `start` and last scene ends at `end`.
+
+    Useful when scenes were detected within a sub-region of a video (e.g. via the `time`
+    command's `-s`/`-e`) but the caller wants the resulting clip boundaries to cover content
+    outside that analysis window.
+
+    Arguments:
+        scenes: List of (start, end) FrameTimecode pairs.
+        start: Desired start of the first scene.
+        end: Desired end of the last scene.
+
+    Returns:
+        A new scene list with the outer endpoints replaced. The input is not modified.
+        An empty input is returned unchanged.
+    """
+    if not scenes:
+        return list(scenes)
+    expanded = list(scenes)
+    expanded[0] = (start, expanded[0][1])
+    expanded[-1] = (expanded[-1][0], end)
+    return expanded
+
+
 def get_scenes_from_cuts(
     cut_list: CutList,
     start_pos: int | FrameTimecode,

--- a/tests/test_scene_manager.py
+++ b/tests/test_scene_manager.py
@@ -20,7 +20,7 @@ import pytest
 from scenedetect.backends.opencv import VideoStreamCv2
 from scenedetect.common import FrameTimecode
 from scenedetect.detectors import AdaptiveDetector, ContentDetector
-from scenedetect.scene_manager import SceneManager
+from scenedetect.scene_manager import SceneManager, expand_scenes_to_bounds
 
 TEST_VIDEO_START_FRAMES_ACTUAL = [150, 180, 394]
 
@@ -210,3 +210,54 @@ def test_crop_invalid():
         sm.crop = (1, 1, 1)  # type: ignore[assignment]
     with pytest.raises(ValueError):
         sm.crop = (1, 1, 1, -1)
+
+
+def test_expand_scenes_to_bounds_two_scenes():
+    """Scenes detected inside a sub-window should be extended outward."""
+    fps = 10.0
+    t0 = FrameTimecode(0, fps)
+    t130 = FrameTimecode(130, fps)
+    t150 = FrameTimecode(150, fps)
+    t170 = FrameTimecode(170, fps)
+    t300 = FrameTimecode(300, fps)
+
+    scenes = [(t130, t150), (t150, t170)]
+    expanded = expand_scenes_to_bounds(scenes, start=t0, end=t300)
+
+    assert expanded == [(t0, t150), (t150, t300)]
+
+
+def test_expand_scenes_to_bounds_empty():
+    """Empty scene lists pass through unchanged."""
+    fps = 10.0
+    assert expand_scenes_to_bounds([], FrameTimecode(0, fps), FrameTimecode(100, fps)) == []
+
+
+def test_expand_scenes_to_bounds_single_scene():
+    """A single scene gets both endpoints extended."""
+    fps = 10.0
+    t0 = FrameTimecode(0, fps)
+    t130 = FrameTimecode(130, fps)
+    t170 = FrameTimecode(170, fps)
+    t300 = FrameTimecode(300, fps)
+
+    scenes = [(t130, t170)]
+    expanded = expand_scenes_to_bounds(scenes, start=t0, end=t300)
+
+    assert expanded == [(t0, t300)]
+
+
+def test_expand_scenes_to_bounds_does_not_mutate_input():
+    """The input scene list must not be modified in place."""
+    fps = 10.0
+    t0 = FrameTimecode(0, fps)
+    t130 = FrameTimecode(130, fps)
+    t150 = FrameTimecode(150, fps)
+    t170 = FrameTimecode(170, fps)
+    t300 = FrameTimecode(300, fps)
+
+    scenes = [(t130, t150), (t150, t170)]
+    original = list(scenes)
+    expand_scenes_to_bounds(scenes, start=t0, end=t300)
+
+    assert scenes == original


### PR DESCRIPTION
## Summary

Resolves #115 (which I filed back in 2020).

Adds a `--expand-to-video` flag to `split-video` so that when scene detection is limited to a sub-region of a video via `time -s/-e`, the resulting split clips extend outward to cover content outside the analysis window. The first output clip extends back to the start of the video, and the last clip extends to the end.

This is useful for files with roughly known split points, where you want to target a specific area only — e.g. a 30-minute file where you know there's a cut somewhere between 13:00 and 17:00. You can limit detection to that range (fast, no false positives elsewhere) and still get two 15-minute clips covering the full video rather than two ~2-minute clips of just the analyzed window.

## Implementation

- New pure helper `expand_scenes_to_bounds(scenes, start, end)` in `scene_manager.py` (sits next to `get_scenes_from_cuts`, same docstring style). Unit-tested in isolation.
- CLI flag `--expand-to-video` on `split-video`, with a matching `expand-to-video` config entry (default `False`).
- `split_video` command handler invokes the helper before dispatching to either ffmpeg or mkvmerge, so both splitters get the expanded list. Falls back to the original scene boundaries with a warning if `video_stream.duration` is `None`.

## Disclosure

I used Claude to help draft this. All code was reviewed and verified by me; the smoke testing below was driven from my end against synthesized fixtures.

## Test plan

- [x] `pytest tests/test_scene_manager.py` — 10/10 pass (6 existing + 4 new unit tests for `expand_scenes_to_bounds`)
- [x] `pytest tests/test_cli.py` — 49 pass, 2 unrelated env failures (missing `pyav`/`moviepy` deps locally)
- [x] `ruff check` and `ruff format --check` clean on all touched files
- [x] End-to-end smoke test on a synthesized 30s, 6-segment color test video (cuts every 5s):
    - **ffmpeg path** with `time -s 12 -e 22` + `--expand-to-video` → 3 clips of ~15s / ~5s / ~10s (keyframe-rounded), first-frame colors red / yellow / magenta
    - **mkvmerge path** with the same args → 3 clips of exactly 15.0s / 5.0s / 10.0s, same red / yellow / magenta colors
    - No `time` window + `--expand-to-video` → no-op, full coverage preserved
    - `time -s 12` only + `--expand-to-video` → first clip extends back to 0
    - `time -e 22` only + `--expand-to-video` → last clip extends to video end