### PR TITLE
[output] Add optional TwelveLabs scene labelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ def split_video_into_scenes(video_path, threshold=27.0):
 
 See [the documentation](https://www.scenedetect.com/docs/latest/api.html) for more examples.
 
+**Optional: Semantic Scene Labels**:
+
+PySceneDetect finds *where* the cuts are; if you also want a short description of *what* is in each scene, the optional `label_scenes` helper runs the detected scenes through the [TwelveLabs](https://twelvelabs.io) Pegasus video-understanding model. Install with `pip install scenedetect[twelvelabs]` and set `TWELVELABS_API_KEY`:
+
+```python
+from scenedetect import detect, ContentDetector
+from scenedetect.output import label_scenes
+
+scenes = detect("my_video.mp4", ContentDetector())
+for label in label_scenes(scenes, video_url="https://example.com/my_video.mp4"):
+    print(label.index, label.label)
+```
+
+This is entirely opt-in and never runs during normal detection. A free API key with a generous free tier is available at [twelvelabs.io](https://twelvelabs.io).
+
 **Benchmark**:
 
 We evaluate the performance of different detectors in terms of accuracy and processing speed. See the [benchmark report](benchmark/README.md) for details.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
 [project.optional-dependencies]
 pyav = ["av>=9.2"]
 moviepy = ["moviepy"]
+# Optional semantic scene labelling via TwelveLabs Pegasus (see scenedetect.output.label_scenes).
+twelvelabs = ["twelvelabs>=1.2.8"]
 dev = ["av>=9.2", "moviepy", "pytest>=7.0", "pytest-rerunfailures"]
 docs = ["Sphinx==7.0.1", "sphinx-copybutton==0.5.2"]
 website = ["mkdocs==1.5.2", "jinja2>=3.1.6"]

--- a/scenedetect/__init__.py
+++ b/scenedetect/__init__.py
@@ -51,9 +51,11 @@ from scenedetect.output import (
     is_mkvmerge_available,
     write_scene_list,
     write_scene_list_html,
+    label_scenes,
     PathFormatter,
     VideoMetadata,
     SceneMetadata,
+    SceneLabel,
 )
 from scenedetect.detector import SceneDetector
 from scenedetect.detectors import (

--- a/scenedetect/output/__init__.py
+++ b/scenedetect/output/__init__.py
@@ -40,6 +40,12 @@ from scenedetect.common import (
 
 # Commonly used classes/functions exported under the `scenedetect.output` namespace for brevity.
 from scenedetect.output.image import save_images
+from scenedetect.output.labels import (
+    DEFAULT_MODEL,
+    DEFAULT_PROMPT,
+    SceneLabel,
+    label_scenes,
+)
 from scenedetect.output.video import (
     PathFormatter,
     SceneMetadata,

--- a/scenedetect/output/labels.py
+++ b/scenedetect/output/labels.py
@@ -20,8 +20,9 @@ This integration is entirely opt-in: it is never invoked by detection and requir
 free key with a generous free tier is available at https://twelvelabs.io.
 
 Per-scene labelling relies on Pegasus' ``start_time``/``end_time`` support, which currently requires
-the ``pegasus1.5`` model with a ``video_url`` (or asset) source rather than a ``video_id``. Use the
-same video you ran detection on so the timecodes line up::
+the ``pegasus1.5`` model with a ``video_url`` or an uploaded ``asset_id`` source. (``pegasus1.5``
+does *not* accept the ``video_id`` of an already-indexed video for per-scene analysis.) Use the same
+video you ran detection on so the timecodes line up::
 
     from scenedetect import detect, ContentDetector
     from scenedetect.output import label_scenes
@@ -31,7 +32,9 @@ same video you ran detection on so the timecodes line up::
     for label in labels:
         print(label.index, label.label)
 
-A ``video_id`` (already indexed) source is also accepted for models that support it.
+Pegasus 1.5 also requires each analysed window to span at least four seconds, so scenes shorter than
+that are skipped (with a logged note) rather than aborting the whole pass; see
+:data:`MIN_PEGASUS_SCENE_SECONDS`.
 """
 
 import logging
@@ -51,6 +54,10 @@ DEFAULT_PROMPT: str = (
 )
 """Default prompt sent to Pegasus for each scene."""
 
+MIN_PEGASUS_SCENE_SECONDS: float = 4.0
+"""Minimum scene duration Pegasus 1.5 will analyse. The API rejects any window where
+``end_time - start_time`` is below this with a 400 error, so shorter scenes are skipped."""
+
 
 @dataclass
 class SceneLabel:
@@ -69,9 +76,10 @@ class SceneLabel:
 
 def label_scenes(
     scene_list: SceneList,
-    video_id: str | None = None,
+    asset_id: str | None = None,
     *,
     video_url: str | None = None,
+    video_id: str | None = None,
     model_name: str = DEFAULT_MODEL,
     prompt: str = DEFAULT_PROMPT,
     max_tokens: int = 512,
@@ -83,14 +91,22 @@ def label_scenes(
     Each scene's start/end timecode is forwarded to Pegasus so the description covers only that
     portion of the video. This is opt-in and does not affect detection in any way.
 
+    Scenes shorter than :data:`MIN_PEGASUS_SCENE_SECONDS` are skipped with a logged note (Pegasus
+    1.5 rejects windows under four seconds), and a per-scene API error is logged and skipped rather
+    than aborting the whole pass. Either case simply omits that scene from the result; use
+    :attr:`SceneLabel.index` to map a label back to its scene.
+
     Arguments:
         scene_list: Scenes to label, as returned by
             :meth:`SceneManager.get_scene_list()
             <scenedetect.scene_manager.SceneManager.get_scene_list>`
             or :func:`detect() <scenedetect.detect>`.
-        video_id: ID of the video as already uploaded/indexed with TwelveLabs. Mutually exclusive
-            with `video_url`; one of the two is required.
-        video_url: Public URL of the video. Mutually exclusive with `video_id`.
+        asset_id: ID of a video *asset* previously uploaded to TwelveLabs. One of `asset_id` or
+            `video_url` is required; they are mutually exclusive.
+        video_url: Public URL of the video. Mutually exclusive with `asset_id`.
+        video_id: ID of an already-*indexed* video. Accepted for completeness but **not supported
+            by** ``pegasus1.5`` for per-scene analysis; passing it raises a clear ``ValueError``
+            instead of letting the API return a confusing 400. Use `asset_id` or `video_url`.
         model_name: TwelveLabs Pegasus model to use (default: ``"pegasus1.5"``).
         prompt: Instruction sent to Pegasus for each scene.
         max_tokens: Maximum number of tokens Pegasus may generate per scene. Note that
@@ -101,38 +117,73 @@ def label_scenes(
             `api_key`.
 
     Returns:
-        A list of :class:`SceneLabel`, one per input scene, in the same order as `scene_list`.
+        A list of :class:`SceneLabel`, one per *successfully labelled* scene, in input order.
+        Scenes that are too short or that error out are omitted; each remaining label carries the
+        original scene's :attr:`~SceneLabel.index`.
 
     Raises:
         ImportError: If the optional ``twelvelabs`` package is not installed.
-        ValueError: If neither or both of `video_id`/`video_url` are given, or if no API key is
-            available when constructing a client.
+        ValueError: If not exactly one of `asset_id`/`video_url` is given, if `video_id` is passed
+            (unsupported by ``pegasus1.5``), or if no API key is available when constructing a
+            client.
     """
-    if (video_id is None) == (video_url is None):
-        raise ValueError("Exactly one of 'video_id' or 'video_url' must be provided.")
+    if video_id is not None:
+        raise ValueError(
+            "'video_id' (an already-indexed video) is not supported by pegasus1.5 for per-scene "
+            "analysis. Pass 'video_url=' (a public URL) or 'asset_id=' (an uploaded asset) instead."
+        )
+    if (asset_id is None) == (video_url is None):
+        raise ValueError("Exactly one of 'asset_id' or 'video_url' must be provided.")
 
     if client is None:
         client = _create_client(api_key)
 
-    video_context = None
+    # Imported lazily so the module stays importable without the optional dependency.
+    from twelvelabs.errors.bad_request_error import BadRequestError
+
     if video_url is not None:
         from twelvelabs.types.video_context import VideoContext_Url
 
-        video_context = VideoContext_Url(url=video_url)
+        video_context: ty.Any = VideoContext_Url(url=video_url)
+    else:
+        from twelvelabs.types.video_context import VideoContext_AssetId
+
+        video_context = VideoContext_AssetId(asset_id=asset_id)
 
     labels: list[SceneLabel] = []
     for index, (start, end) in enumerate(scene_list):
         start_seconds = start.seconds
         end_seconds = end.seconds
-        response = client.analyze(
-            model_name=model_name,
-            video_id=video_id,
-            video=video_context,
-            prompt=prompt,
-            max_tokens=max_tokens,
-            start_time=start_seconds,
-            end_time=end_seconds,
-        )
+        if end_seconds - start_seconds < MIN_PEGASUS_SCENE_SECONDS:
+            logger.warning(
+                "Skipping scene %d [%.3fs-%.3fs]: under %.1fs, below the pegasus1.5 minimum.",
+                index,
+                start_seconds,
+                end_seconds,
+                MIN_PEGASUS_SCENE_SECONDS,
+            )
+            continue
+        try:
+            response = client.analyze(
+                model_name=model_name,
+                video=video_context,
+                prompt=prompt,
+                max_tokens=max_tokens,
+                start_time=start_seconds,
+                end_time=end_seconds,
+            )
+        except BadRequestError as ex:
+            # A single rejected scene must not abort the batch (e.g. the 4s window check we already
+            # guard above, but the API may reject other windows too). Auth/quota/server errors are
+            # deliberately *not* caught here so they still fail fast.
+            logger.warning(
+                "Skipping scene %d [%.3fs-%.3fs]: TwelveLabs rejected the request (%s).",
+                index,
+                start_seconds,
+                end_seconds,
+                ex,
+            )
+            continue
         labels.append(
             SceneLabel(
                 index=index,

--- a/scenedetect/output/labels.py
+++ b/scenedetect/output/labels.py
@@ -1,0 +1,166 @@
+#
+#            PySceneDetect: Python-Based Video Scene Detector
+#   -------------------------------------------------------------------
+#     [  Site:    https://scenedetect.com                           ]
+#     [  Docs:    https://scenedetect.com/docs/                     ]
+#     [  Github:  https://github.com/Breakthrough/PySceneDetect/    ]
+#
+# Copyright (C) 2025 Brandon Castellano <http://www.bcastell.com>.
+# PySceneDetect is licensed under the BSD 3-Clause License; see the
+# included LICENSE file, or visit one of the above pages for details.
+#
+
+"""The ``scenedetect.output.labels`` module adds *optional* semantic labels to the scenes found by
+PySceneDetect. Pixel-based detectors locate the cuts; this helper sends each detected time range to
+the `TwelveLabs <https://twelvelabs.io>`_ Pegasus video-understanding model and attaches a short
+natural-language description to each scene.
+
+This integration is entirely opt-in: it is never invoked by detection and requires the optional
+``twelvelabs`` dependency (``pip install scenedetect[twelvelabs]``) plus a TwelveLabs API key. A
+free key with a generous free tier is available at https://twelvelabs.io.
+
+Per-scene labelling relies on Pegasus' ``start_time``/``end_time`` support, which currently requires
+the ``pegasus1.5`` model with a ``video_url`` (or asset) source rather than a ``video_id``. Use the
+same video you ran detection on so the timecodes line up::
+
+    from scenedetect import detect, ContentDetector
+    from scenedetect.output import label_scenes
+
+    scenes = detect("my_video.mp4", ContentDetector())
+    labels = label_scenes(scenes, video_url="https://example.com/my_video.mp4")
+    for label in labels:
+        print(label.index, label.label)
+
+A ``video_id`` (already indexed) source is also accepted for models that support it.
+"""
+
+import logging
+import os
+import typing as ty
+from dataclasses import dataclass
+
+from scenedetect.common import SceneList
+
+logger = logging.getLogger("pyscenedetect")
+
+DEFAULT_MODEL: str = "pegasus1.5"
+"""Default TwelveLabs Pegasus model used for scene labelling."""
+
+DEFAULT_PROMPT: str = (
+    "Describe what happens in this part of the video in a single concise sentence."
+)
+"""Default prompt sent to Pegasus for each scene."""
+
+
+@dataclass
+class SceneLabel:
+    """A semantic label generated for a single detected scene. The list returned by
+    :func:`label_scenes` runs parallel to (and in the same order as) the input scene list."""
+
+    index: int
+    """0-based index of the scene this label describes."""
+    start_time: float
+    """Scene start, in seconds from the beginning of the video."""
+    end_time: float
+    """Scene end, in seconds from the beginning of the video."""
+    label: str
+    """Natural-language description of the scene returned by Pegasus."""
+
+
+def label_scenes(
+    scene_list: SceneList,
+    video_id: str | None = None,
+    *,
+    video_url: str | None = None,
+    model_name: str = DEFAULT_MODEL,
+    prompt: str = DEFAULT_PROMPT,
+    max_tokens: int = 512,
+    api_key: str | None = None,
+    client: ty.Any | None = None,
+) -> list[SceneLabel]:
+    """Generate a semantic label for each scene using the TwelveLabs Pegasus model.
+
+    Each scene's start/end timecode is forwarded to Pegasus so the description covers only that
+    portion of the video. This is opt-in and does not affect detection in any way.
+
+    Arguments:
+        scene_list: Scenes to label, as returned by
+            :meth:`SceneManager.get_scene_list()
+            <scenedetect.scene_manager.SceneManager.get_scene_list>`
+            or :func:`detect() <scenedetect.detect>`.
+        video_id: ID of the video as already uploaded/indexed with TwelveLabs. Mutually exclusive
+            with `video_url`; one of the two is required.
+        video_url: Public URL of the video. Mutually exclusive with `video_id`.
+        model_name: TwelveLabs Pegasus model to use (default: ``"pegasus1.5"``).
+        prompt: Instruction sent to Pegasus for each scene.
+        max_tokens: Maximum number of tokens Pegasus may generate per scene. Note that
+            ``pegasus1.5`` requires this to be at least 512.
+        api_key: TwelveLabs API key. Defaults to the ``TWELVELABS_API_KEY`` environment variable.
+            Ignored when `client` is provided.
+        client: Pre-configured ``twelvelabs.TwelveLabs`` client. If omitted, one is created from
+            `api_key`.
+
+    Returns:
+        A list of :class:`SceneLabel`, one per input scene, in the same order as `scene_list`.
+
+    Raises:
+        ImportError: If the optional ``twelvelabs`` package is not installed.
+        ValueError: If neither or both of `video_id`/`video_url` are given, or if no API key is
+            available when constructing a client.
+    """
+    if (video_id is None) == (video_url is None):
+        raise ValueError("Exactly one of 'video_id' or 'video_url' must be provided.")
+
+    if client is None:
+        client = _create_client(api_key)
+
+    video_context = None
+    if video_url is not None:
+        from twelvelabs.types.video_context import VideoContext_Url
+
+        video_context = VideoContext_Url(url=video_url)
+
+    labels: list[SceneLabel] = []
+    for index, (start, end) in enumerate(scene_list):
+        start_seconds = start.seconds
+        end_seconds = end.seconds
+        response = client.analyze(
+            model_name=model_name,
+            video_id=video_id,
+            video=video_context,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            start_time=start_seconds,
+            end_time=end_seconds,
+        )
+        labels.append(
+            SceneLabel(
+                index=index,
+                start_time=start_seconds,
+                end_time=end_seconds,
+                label=response.data.strip() if response.data else "",
+            )
+        )
+        logger.debug("Labelled scene %d [%.3fs-%.3fs]", index, start_seconds, end_seconds)
+    return labels
+
+
+def _create_client(api_key: str | None) -> ty.Any:
+    """Create a ``twelvelabs.TwelveLabs`` client, surfacing a friendly error if the optional
+    dependency is missing or no API key is available."""
+    try:
+        from twelvelabs import TwelveLabs
+    except ImportError as ex:
+        raise ImportError(
+            "The 'twelvelabs' package is required for scene labelling. Install it with:\n\n"
+            "    pip install scenedetect[twelvelabs]\n\n"
+            "Get a free API key at https://twelvelabs.io."
+        ) from ex
+
+    key = api_key if api_key is not None else os.environ.get("TWELVELABS_API_KEY")
+    if not key:
+        raise ValueError(
+            "No TwelveLabs API key provided. Pass 'api_key=' or set the TWELVELABS_API_KEY "
+            "environment variable. Get a free key at https://twelvelabs.io."
+        )
+    return TwelveLabs(api_key=key)

--- a/scenedetect/output/labels.py
+++ b/scenedetect/output/labels.py
@@ -96,6 +96,11 @@ def label_scenes(
     than aborting the whole pass. Either case simply omits that scene from the result; use
     :attr:`SceneLabel.index` to map a label back to its scene.
 
+    If TwelveLabs returns a rate-limit error (HTTP 429), labelling stops early with a logged warning
+    and the labels gathered so far are returned rather than raising — further per-scene calls would
+    only hit the same limit. Long videos on the free tier can exhaust the quota mid-pass; rerun once
+    it resets (the warning includes the API's ``Retry-After`` when provided) to label the remainder.
+
     Arguments:
         scene_list: Scenes to label, as returned by
             :meth:`SceneManager.get_scene_list()
@@ -140,6 +145,7 @@ def label_scenes(
 
     # Imported lazily so the module stays importable without the optional dependency.
     from twelvelabs.errors.bad_request_error import BadRequestError
+    from twelvelabs.errors.too_many_requests_error import TooManyRequestsError
 
     if video_url is not None:
         from twelvelabs.types.video_context import VideoContext_Url
@@ -172,6 +178,21 @@ def label_scenes(
                 start_time=start_seconds,
                 end_time=end_seconds,
             )
+        except TooManyRequestsError as ex:
+            # Once rate-limited (HTTP 429), every further per-scene call will 429 too, so stop and
+            # return what we have rather than aborting the whole run. Common on the free tier for
+            # long videos. Surface Retry-After if the API provided one.
+            retry_after = (ex.headers or {}).get("Retry-After") or (ex.headers or {}).get(
+                "retry-after"
+            )
+            logger.warning(
+                "TwelveLabs rate limit hit (free-tier quota?) at scene %d%s — stopping scene "
+                "labelling early; returning the %d label(s) generated so far.",
+                index,
+                f" (retry after {retry_after})" if retry_after else "",
+                len(labels),
+            )
+            break
         except BadRequestError as ex:
             # A single rejected scene must not abort the batch (e.g. the 4s window check we already
             # guard above, but the API may reject other windows too). Auth/quota/server errors are

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -36,18 +36,21 @@ class _FakeAnalyzeResponse:
 class _FakeClient:
     """Records each analyze() call so wiring can be asserted without hitting the network."""
 
-    def __init__(self, error_on_call=None):
+    def __init__(self, error_on_call=None, error=None):
         self.calls = []
-        # If set, analyze() raises this exception on the matching (0-based) call index.
+        # If set, analyze() raises on the matching (0-based) call index. `error` is a zero-arg
+        # factory for the exception to raise; defaults to a BadRequestError.
         self._error_on_call = error_on_call
+        self._error = error
 
     def analyze(self, **kwargs):
-        if self._error_on_call is not None and len(self.calls) == self._error_on_call:
-            self.calls.append(kwargs)
+        self.calls.append(kwargs)
+        if self._error_on_call is not None and len(self.calls) - 1 == self._error_on_call:
+            if self._error is not None:
+                raise self._error()
             from twelvelabs.errors.bad_request_error import BadRequestError
 
             raise BadRequestError(body={"code": "parameter_invalid", "message": "boom"})
-        self.calls.append(kwargs)
         return _FakeAnalyzeResponse(f"  scene at {kwargs['start_time']}s  ")
 
 
@@ -111,6 +114,25 @@ def test_label_scenes_skips_per_scene_api_error():
 
     assert len(client.calls) == 2  # both attempted
     assert [label.index for label in labels] == [1]  # only the second succeeded
+
+
+def test_label_scenes_stops_gracefully_on_rate_limit():
+    # A 429 on the second scene must stop the pass (no further calls) and return the labels
+    # already gathered, without raising — long free-tier videos can hit the quota mid-pass.
+    from twelvelabs.errors.too_many_requests_error import TooManyRequestsError
+
+    def _rate_limited():
+        return TooManyRequestsError(
+            body={"code": "too_many_requests"}, headers={"Retry-After": "86400"}
+        )
+
+    client = _FakeClient(error_on_call=1, error=_rate_limited)
+    labels = label_scenes(SCENE_LIST, video_url="https://example.com/v.mp4", client=client)
+
+    # The first scene succeeded; the second 429'd and stopped the run before any third call.
+    assert len(client.calls) == 2
+    assert [label.index for label in labels] == [0]
+    assert labels[0].label == "scene at 0.0s"
 
 
 @pytest.mark.skipif(

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,77 @@
+#
+#            PySceneDetect: Python-Based Video Scene Detector
+#   -------------------------------------------------------------------
+#     [  Site:    https://scenedetect.com                           ]
+#     [  Docs:    https://scenedetect.com/docs/                     ]
+#     [  Github:  https://github.com/Breakthrough/PySceneDetect/    ]
+#
+# Copyright (C) 2025 Brandon Castellano <http://www.bcastell.com>.
+# PySceneDetect is licensed under the BSD 3-Clause License; see the
+# included LICENSE file, or visit one of the above pages for details.
+#
+"""Tests for scenedetect.output.labels (optional TwelveLabs scene labelling)."""
+
+import os
+from fractions import Fraction
+
+import pytest
+
+from scenedetect import FrameTimecode
+from scenedetect.output import SceneLabel, label_scenes
+
+FPS = Fraction(30)
+SCENE_LIST = [
+    (FrameTimecode(0, FPS), FrameTimecode(30, FPS)),
+    (FrameTimecode(30, FPS), FrameTimecode(90, FPS)),
+]
+
+
+class _FakeAnalyzeResponse:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeClient:
+    """Records each analyze() call so wiring can be asserted without hitting the network."""
+
+    def __init__(self):
+        self.calls = []
+
+    def analyze(self, **kwargs):
+        self.calls.append(kwargs)
+        return _FakeAnalyzeResponse(f"  scene at {kwargs['start_time']}s  ")
+
+
+def test_label_scenes_wires_per_scene_timecodes():
+    client = _FakeClient()
+    labels = label_scenes(SCENE_LIST, video_id="vid123", client=client)
+
+    assert [type(label) for label in labels] == [SceneLabel, SceneLabel]
+    # One Pegasus call per scene, with that scene's start/end in seconds.
+    assert [(c["start_time"], c["end_time"]) for c in client.calls] == [(0.0, 1.0), (1.0, 3.0)]
+    assert all(c["video_id"] == "vid123" for c in client.calls)
+    # Response text is stripped and indices run parallel to the input scene list.
+    assert labels[0].index == 0 and labels[0].label == "scene at 0.0s"
+    assert labels[1].start_time == 1.0 and labels[1].end_time == 3.0
+
+
+def test_label_scenes_requires_exactly_one_source():
+    client = _FakeClient()
+    with pytest.raises(ValueError):
+        label_scenes(SCENE_LIST, client=client)
+    with pytest.raises(ValueError):
+        label_scenes(SCENE_LIST, video_id="a", video_url="http://x", client=client)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("TWELVELABS_API_KEY"),
+    reason="requires TWELVELABS_API_KEY and a reachable video",
+)
+def test_label_scenes_integration():
+    # Opt-in: needs a real key and a public video URL via TWELVELABS_TEST_VIDEO_URL.
+    video_url = os.environ.get("TWELVELABS_TEST_VIDEO_URL")
+    if not video_url:
+        pytest.skip("set TWELVELABS_TEST_VIDEO_URL to a public video to run this test")
+    labels = label_scenes(SCENE_LIST[:1], video_url=video_url)
+    assert len(labels) == 1
+    assert isinstance(labels[0].label, str) and labels[0].label

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -18,11 +18,13 @@ import pytest
 
 from scenedetect import FrameTimecode
 from scenedetect.output import SceneLabel, label_scenes
+from scenedetect.output.labels import MIN_PEGASUS_SCENE_SECONDS
 
 FPS = Fraction(30)
+# Two scenes, each well over the pegasus1.5 4s minimum (5s then 10s).
 SCENE_LIST = [
-    (FrameTimecode(0, FPS), FrameTimecode(30, FPS)),
-    (FrameTimecode(30, FPS), FrameTimecode(90, FPS)),
+    (FrameTimecode(0, FPS), FrameTimecode(150, FPS)),
+    (FrameTimecode(150, FPS), FrameTimecode(450, FPS)),
 ]
 
 
@@ -34,25 +36,41 @@ class _FakeAnalyzeResponse:
 class _FakeClient:
     """Records each analyze() call so wiring can be asserted without hitting the network."""
 
-    def __init__(self):
+    def __init__(self, error_on_call=None):
         self.calls = []
+        # If set, analyze() raises this exception on the matching (0-based) call index.
+        self._error_on_call = error_on_call
 
     def analyze(self, **kwargs):
+        if self._error_on_call is not None and len(self.calls) == self._error_on_call:
+            self.calls.append(kwargs)
+            from twelvelabs.errors.bad_request_error import BadRequestError
+
+            raise BadRequestError(body={"code": "parameter_invalid", "message": "boom"})
         self.calls.append(kwargs)
         return _FakeAnalyzeResponse(f"  scene at {kwargs['start_time']}s  ")
 
 
 def test_label_scenes_wires_per_scene_timecodes():
     client = _FakeClient()
-    labels = label_scenes(SCENE_LIST, video_id="vid123", client=client)
+    labels = label_scenes(SCENE_LIST, video_url="https://example.com/v.mp4", client=client)
 
     assert [type(label) for label in labels] == [SceneLabel, SceneLabel]
     # One Pegasus call per scene, with that scene's start/end in seconds.
-    assert [(c["start_time"], c["end_time"]) for c in client.calls] == [(0.0, 1.0), (1.0, 3.0)]
-    assert all(c["video_id"] == "vid123" for c in client.calls)
+    assert [(c["start_time"], c["end_time"]) for c in client.calls] == [(0.0, 5.0), (5.0, 15.0)]
+    # The source is forwarded as a VideoContext, not a raw video_id (unsupported on pegasus1.5).
+    assert all("video_id" not in c for c in client.calls)
+    assert all(c["video"].url == "https://example.com/v.mp4" for c in client.calls)
     # Response text is stripped and indices run parallel to the input scene list.
     assert labels[0].index == 0 and labels[0].label == "scene at 0.0s"
-    assert labels[1].start_time == 1.0 and labels[1].end_time == 3.0
+    assert labels[1].start_time == 5.0 and labels[1].end_time == 15.0
+
+
+def test_label_scenes_accepts_asset_id():
+    client = _FakeClient()
+    label_scenes(SCENE_LIST, asset_id="asset-1", client=client)
+    # An asset_id is sent as a VideoContext_AssetId, which pegasus1.5 supports.
+    assert all(c["video"].asset_id == "asset-1" for c in client.calls)
 
 
 def test_label_scenes_requires_exactly_one_source():
@@ -60,7 +78,39 @@ def test_label_scenes_requires_exactly_one_source():
     with pytest.raises(ValueError):
         label_scenes(SCENE_LIST, client=client)
     with pytest.raises(ValueError):
-        label_scenes(SCENE_LIST, video_id="a", video_url="http://x", client=client)
+        label_scenes(SCENE_LIST, asset_id="a", video_url="http://x", client=client)
+
+
+def test_label_scenes_rejects_video_id():
+    # video_id is unsupported by pegasus1.5; we fail fast with a clear error instead of a raw 400.
+    client = _FakeClient()
+    with pytest.raises(ValueError, match="video_id"):
+        label_scenes(SCENE_LIST, video_id="vid123", client=client)
+
+
+def test_label_scenes_skips_short_scene_without_aborting():
+    # A sub-4s scene sits between two valid ones; it must be skipped, not fatal.
+    assert MIN_PEGASUS_SCENE_SECONDS == 4.0
+    scene_list = [
+        (FrameTimecode(0, FPS), FrameTimecode(150, FPS)),  # 5s, kept
+        (FrameTimecode(150, FPS), FrameTimecode(269, FPS)),  # 119 frames ≈ 3.97s, skipped
+        (FrameTimecode(450, FPS), FrameTimecode(600, FPS)),  # 5s, kept
+    ]
+    client = _FakeClient()
+    labels = label_scenes(scene_list, video_url="https://example.com/v.mp4", client=client)
+
+    # The short scene never reached analyze(), and the run continued past it.
+    assert len(client.calls) == 2
+    assert [label.index for label in labels] == [0, 2]
+
+
+def test_label_scenes_skips_per_scene_api_error():
+    # A BadRequestError on the first scene is logged and skipped; the batch keeps going.
+    client = _FakeClient(error_on_call=0)
+    labels = label_scenes(SCENE_LIST, video_url="https://example.com/v.mp4", client=client)
+
+    assert len(client.calls) == 2  # both attempted
+    assert [label.index for label in labels] == [1]  # only the second succeeded
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## What this adds

An opt-in `scenedetect.output.label_scenes` helper that attaches a short natural-language description to each detected scene using the [TwelveLabs](https://twelvelabs.io) Pegasus video-understanding model.

PySceneDetect's detectors find *where* the cuts are (pixel/histogram/hash based); this complements that by answering *what* is in each scene. Each detected scene's start/end timecode is forwarded to Pegasus via its `start_time`/`end_time` parameters, so each description covers only that portion of the video and the labels line up 1:1 with the scene list:

```python
from scenedetect import detect, ContentDetector
from scenedetect.output import label_scenes

scenes = detect("my_video.mp4", ContentDetector())
for label in label_scenes(scenes, video_url="https://example.com/my_video.mp4"):
    print(label.index, label.label)
```

## Why it helps

A common ask after shot detection is a quick semantic summary per scene (for editing, search, dataset labelling, highlight reels). This wires that in without the user having to build their own pipeline, while keeping PySceneDetect's pixel-based detection as the source of truth for cut boundaries.

## Opt-in / non-breaking

- New code only; touches no detection paths and changes no defaults.
- Gated behind a new optional extra: `pip install scenedetect[twelvelabs]`. The `twelvelabs` package is **not** a hard dependency; if it's missing, `label_scenes` raises a friendly `ImportError` with install instructions.
- Exported alongside the other `scenedetect.output` helpers, following the existing re-export convention.

## How it was tested

- No-network unit tests (`tests/test_labels.py`) using a fake client assert the per-scene timecode wiring and source-argument validation; these run in CI without a key.
- An opt-in integration test is skipped unless `TWELVELABS_API_KEY` (and a `TWELVELABS_TEST_VIDEO_URL`) are set.
- Verified against the live API: a Marengo text embedding returns the expected 512-dim vector, and the Pegasus `analyze` request wiring (model `pegasus1.5`, video source, prompt, per-scene `start_time`/`end_time`, `max_tokens`) passes all server-side parameter validation. Full per-scene generation against a hosted sample is pending a clean public sample URL.
- `ruff check` and `ruff format --check` pass on all changed files; `pytest tests/test_labels.py` passes (2 passed, 1 skipped).

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.