### PR TITLE
Fix AdaptiveDetector min_scene_len target frame check

### DIFF
--- a/scenedetect/detectors/adaptive_detector.py
+++ b/scenedetect/detectors/adaptive_detector.py
@@ -136,7 +136,7 @@ class AdaptiveDetector(ContentDetector):
         threshold_met: bool = (
             adaptive_ratio >= self.adaptive_threshold and target_score >= self.min_content_val
         )
-        min_length_met: bool = (timecode - self._last_cut) >= self.min_scene_len
+        min_length_met: bool = (target_timecode - self._last_cut) >= self.min_scene_len
         if threshold_met and min_length_met:
             self._last_cut = target_timecode
             return [target_timecode]

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -19,6 +19,7 @@ test case material.
 import os
 from dataclasses import dataclass
 
+import numpy
 import pytest
 
 from scenedetect import FrameTimecode, SceneDetector, SceneManager, StatsManager, detect
@@ -246,3 +247,33 @@ def test_min_scene_len_accepts_time_values(detector_type, min_scene_len):
     scene_list = test_case.detect()
     start_frames = [timecode.frame_num for timecode, _ in scene_list]
     assert start_frames == test_case.scene_boundaries
+
+
+def test_adaptive_detector_uses_target_frame_for_min_scene_len():
+    """AdaptiveDetector applies min_scene_len to the buffered target frame."""
+
+    class ScoreAdaptiveDetector(AdaptiveDetector):
+        def __init__(self, scores: dict[int, float]):
+            super().__init__(
+                adaptive_threshold=3.0,
+                min_scene_len=24,
+                min_content_val=10.0,
+                window_width=20,
+            )
+            self._scores = scores
+
+        def _calculate_frame_score(
+            self, timecode: FrameTimecode, frame_img: numpy.ndarray
+        ) -> float:
+            return self._scores.get(timecode.frame_num, 0.0)
+
+    detector = ScoreAdaptiveDetector({100: 100.0, 104: 100.0})
+    frame = numpy.zeros((1, 1, 3), dtype=numpy.uint8)
+
+    cuts = [
+        cut.frame_num
+        for frame_num in range(130)
+        for cut in detector.process_frame(FrameTimecode(frame_num, fps=30.0), frame)
+    ]
+
+    assert cuts == [100]


### PR DESCRIPTION
## Summary
- apply `AdaptiveDetector`'s `min_scene_len` check to the buffered target frame instead of the delayed/current frame
- add a synthetic regression test for two adaptive spikes that are only four target frames apart

Fixes #408

## Verification
- `python -m pytest tests/test_detectors.py::test_adaptive_detector_uses_target_frame_for_min_scene_len tests/test_detectors.py -q`
- `python -m ruff check scenedetect/detectors/adaptive_detector.py tests/test_detectors.py`
- `git diff --check`