### PR TITLE
[bugfix] Fix progress bar accuracy for VFR videos

### DIFF
--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -571,6 +571,7 @@ class SceneManager:
         )
         decode_thread.start()
         frame_im = None
+        prev_position = None
 
         logger.info("Detecting scenes...")
         try:
@@ -581,13 +582,22 @@ class SceneManager:
                 if next_frame is not None:
                     frame_im = next_frame
                 assert frame_im is not None
+                if prev_position is None:
+                    prev_position = self._start_pos
+                assert prev_position is not None
                 new_cuts = self._process_frame(position, frame_im, callback)
                 if progress_bar is not None:
                     if new_cuts:
                         progress_bar.set_description(
                             PROGRESS_BAR_DESCRIPTION % len(self._cutting_list), refresh=False
                         )
-                    progress_bar.update(1 + frame_skip)
+                    # Increment progress bar by delta of position.frame_num instead of 1
+                    # to handle VFR video where frame count is an approximation.
+                    # First frame increments by 1 as base case.
+                    delta_pos = position.frame_num - prev_position.frame_num
+                    is_first_frame = position.frame_num == 0
+                    progress_bar.update((1 if is_first_frame else delta_pos) + frame_skip)
+                    prev_position = position
         finally:
             if progress_bar is not None:
                 progress_bar.set_description(

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -582,9 +582,6 @@ class SceneManager:
                 if next_frame is not None:
                     frame_im = next_frame
                 assert frame_im is not None
-                if prev_position is None:
-                    prev_position = self._start_pos
-                assert prev_position is not None
                 new_cuts = self._process_frame(position, frame_im, callback)
                 if progress_bar is not None:
                     if new_cuts:
@@ -593,10 +590,8 @@ class SceneManager:
                         )
                     # Increment progress bar by delta of position.frame_num instead of 1
                     # to handle VFR video where frame count is an approximation.
-                    # First frame increments by 1 as base case.
-                    delta_pos = position.frame_num - prev_position.frame_num
-                    is_first_frame = position.frame_num == 0
-                    progress_bar.update((1 if is_first_frame else delta_pos) + frame_skip)
+                    delta = 1 if prev_position is None else position.frame_num - prev_position.frame_num
+                    progress_bar.update(delta)
                     prev_position = position
         finally:
             if progress_bar is not None:

--- a/scenedetect/scene_manager.py
+++ b/scenedetect/scene_manager.py
@@ -590,7 +590,9 @@ class SceneManager:
                         )
                     # Increment progress bar by delta of position.frame_num instead of 1
                     # to handle VFR video where frame count is an approximation.
-                    delta = 1 if prev_position is None else position.frame_num - prev_position.frame_num
+                    delta = (
+                        1 if prev_position is None else position.frame_num - prev_position.frame_num
+                    )
                     progress_bar.update(delta)
                     prev_position = position
         finally:


### PR DESCRIPTION
- Addresses progress bar behavior mentioned in Issue #561 where progress bar only goes up to ~80% with VFR videos, even with PyAV backend.

- Progress bar now goes up to 100% for both PyAV and OpenCV backends.

- Please note that this PR does not address the main topic of Issue #561 (Invalid end time in scene lists for VFR videos) which was determined to be unique to the OpenCV backend and is not present when using PyAV.