### PR TITLE
Add deprecation warnings for legacy framerate aliases

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -67,7 +67,7 @@ Options
 
 .. option:: --framerate FPS
 
-  [DEPRECATED] Use :option:`-f/--frame-rate <-f>` instead.
+  Alias of :option:`-f/--frame-rate <-f>`.
 
 .. option:: -m TIMECODE, --min-scene-len TIMECODE
 

--- a/docs/cli/backends.rst
+++ b/docs/cli/backends.rst
@@ -19,7 +19,7 @@ The `OpenCV <https://opencv.org/>`_ backend (usually `opencv-python <https://pyp
 
 It is mostly reliable and fast, although can occasionally run into issues processing videos with multiple audio tracks or small amounts of frame corruption. You can use a custom version of the ``cv2`` package, or install either the `opencv-python` or `opencv-python-headless` packages from `pip`.
 
-The OpenCV backend also supports image sequences as inputs (e.g. ``frame%02d.jpg`` if you want to load frame001.jpg, frame002.jpg, frame003.jpg...). Make sure to specify the framerate manually (``-f``/``--framerate``) to ensure accurate timing calculations.
+The OpenCV backend also supports image sequences as inputs (e.g. ``frame%02d.jpg`` if you want to load frame001.jpg, frame002.jpg, frame003.jpg...). Make sure to specify the framerate manually (``-f``/``--frame-rate``) to ensure accurate timing calculations.
 
 Variable framerate (VFR) video is supported. Scene detection uses PTS-derived timestamps from ``CAP_PROP_POS_MSEC`` for accurate timecodes. Seeking compensates for OpenCV's average-fps-based internal seek approximation, so output timecodes remain accurate across the full video.
 

--- a/scenedetect/__init__.py
+++ b/scenedetect/__init__.py
@@ -15,6 +15,7 @@ can be used to open a video for a
 :class:`SceneManager <scenedetect.scene_manager.SceneManager>`.
 """
 
+import warnings
 from logging import getLogger
 
 # OpenCV is a required package, but we don't have it as an explicit dependency since we
@@ -115,8 +116,13 @@ def open_video(
         :class:`VideoOpenFailure`: Constructing the VideoStream fails. If multiple backends have
             been attempted, the error from the first backend will be returned.
     """
-    # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning when `framerate=` is
-    # used, once internal callers and downstream users have had a release to migrate.
+    if framerate is not None:
+        warnings.warn(
+            "`framerate` is deprecated and scheduled for removal in v0.9; "
+            "use `frame_rate` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if frame_rate is None:
         frame_rate = framerate
     # A list of paths is opened as a single concatenated stream. VideoStreamConcat handles

--- a/scenedetect/_cli/__init__.py
+++ b/scenedetect/_cli/__init__.py
@@ -22,6 +22,7 @@ import inspect
 import logging
 import os
 import os.path
+import warnings
 from copy import copy
 
 import click
@@ -361,8 +362,13 @@ def scenedetect(
     ctx = ctx.obj
     assert isinstance(ctx, CliContext)
 
-    # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning when `--framerate`
-    # is used, once downstream users have had a release to migrate to `--frame-rate`.
+    if framerate_legacy is not None:
+        warnings.warn(
+            "`--framerate` is deprecated; use `--frame-rate` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     if frame_rate is None:
         frame_rate = framerate_legacy
     elif framerate_legacy is not None:

--- a/scenedetect/_cli/__init__.py
+++ b/scenedetect/_cli/__init__.py
@@ -22,7 +22,6 @@ import inspect
 import logging
 import os
 import os.path
-import warnings
 from copy import copy
 
 import click
@@ -238,14 +237,15 @@ Global options (e.g. -i/--input, -c/--config) must be specified before any comma
     default=None,
     help="Override frame rate with value as frames/sec.",
 )
+# Keep --framerate separate so Click can hide it while mapping both spellings to frame_rate.
 @click.option(
     "--framerate",
-    "framerate_legacy",
+    "frame_rate",
     metavar="FPS",
     type=click.FLOAT,
     default=None,
     hidden=True,
-    help="[DEPRECATED] Use -f/--frame-rate instead.",
+    help="Alias of -f/--frame-rate.",
 )
 @click.option(
     "--min-scene-len",
@@ -347,7 +347,6 @@ def scenedetect(
     stats: str | None,
     config: str | None,
     frame_rate: float | None,
-    framerate_legacy: float | None,
     min_scene_len: str | None,
     drop_short_scenes: bool | None,
     merge_last_scene: bool | None,
@@ -361,18 +360,6 @@ def scenedetect(
 ):
     ctx = ctx.obj
     assert isinstance(ctx, CliContext)
-
-    if framerate_legacy is not None:
-        warnings.warn(
-            "`--framerate` is deprecated; use `--frame-rate` instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-
-    if frame_rate is None:
-        frame_rate = framerate_legacy
-    elif framerate_legacy is not None:
-        logger.warning("Both --frame-rate and --framerate were specified; using --frame-rate.")
 
     ctx.handle_options(
         input_path=input,

--- a/scenedetect/backends/moviepy.py
+++ b/scenedetect/backends/moviepy.py
@@ -19,6 +19,7 @@ image sequences or AviSynth scripts are supported as inputs.
 import os
 import time
 import typing as ty
+import warnings
 from fractions import Fraction
 from logging import getLogger
 
@@ -94,8 +95,13 @@ class VideoStreamMoviePy(VideoStream):
         """
         super().__init__()
 
-        # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning when `framerate=` is
-        # used, once internal callers and downstream users have had a release to migrate.
+        if framerate is not None:
+            warnings.warn(
+                "`framerate` is deprecated and scheduled for removal in v0.9; "
+                "use `frame_rate` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if frame_rate is None:
             frame_rate = framerate
         # TODO: Investigate how MoviePy handles ffmpeg not being on PATH.

--- a/scenedetect/backends/opencv.py
+++ b/scenedetect/backends/opencv.py
@@ -101,8 +101,13 @@ class VideoStreamCv2(VideoStream):
             ValueError: specified frame rate is invalid
         """
         super().__init__()
-        # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning when `framerate=` is
-        # used, once internal callers and downstream users have had a release to migrate.
+        if framerate is not None:
+            warnings.warn(
+                "`framerate` is deprecated and scheduled for removal in v0.9; "
+                "use `frame_rate` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if frame_rate is None:
             frame_rate = framerate
         if path_or_device is not None:
@@ -395,8 +400,13 @@ class VideoCaptureAdapter(VideoStream):
         """
         super().__init__()
 
-        # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning when `framerate=` is
-        # used, once internal callers and downstream users have had a release to migrate.
+        if framerate is not None:
+            warnings.warn(
+                "`framerate` is deprecated and scheduled for removal in v0.9; "
+                "use `frame_rate` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if frame_rate is None:
             frame_rate = framerate
         if frame_rate is not None and frame_rate < MAX_FPS_DELTA:

--- a/scenedetect/backends/pyav.py
+++ b/scenedetect/backends/pyav.py
@@ -13,6 +13,7 @@
 
 import os
 import typing as ty
+import warnings
 from fractions import Fraction
 from logging import getLogger
 
@@ -89,8 +90,13 @@ class VideoStreamAv(VideoStream):
         # refinement for frames FFmpeg flags as corrupt but still decodes.
         super().__init__()
 
-        # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning when `framerate=` is
-        # used, once internal callers and downstream users have had a release to migrate.
+        if framerate is not None:
+            warnings.warn(
+                "`framerate` is deprecated and scheduled for removal in v0.9; "
+                "use `frame_rate` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         if frame_rate is None:
             frame_rate = framerate
         # Ensure specified frame rate is valid if set.

--- a/scenedetect/common.py
+++ b/scenedetect/common.py
@@ -296,8 +296,12 @@ class FrameTimecode:
         property returns an exact :class:`fractions.Fraction` and matches the naming used by
         :attr:`scenedetect.video_stream.VideoStream.frame_rate`.
         """
-        # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning here once internal
-        # callers and downstream users have had a release to migrate to `frame_rate`.
+        warnings.warn(
+            "`framerate` is deprecated and scheduled for removal in v0.9; "
+            "use `frame_rate` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._rate is None:
             return None
         return float(self._rate)
@@ -335,16 +339,18 @@ class FrameTimecode:
     def get_framerate(self) -> float | None:
         """[DEPRECATED] Get Framerate: Returns the framerate used by the FrameTimecode object.
 
-        Use the `framerate` property instead.
+        Use the `frame_rate` property instead.
 
         :meta private:
         """
         warnings.warn(
-            "get_framerate() is deprecated, use the `framerate` property instead.",
+            "get_framerate() is deprecated, use the `frame_rate` property instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.framerate
+        if self.frame_rate is None:
+            return None
+        return float(self.frame_rate)
 
     def equal_frame_rate(self, other: "float | Fraction | FrameTimecode") -> bool:
         """Determine whether the passed frame rate equals this object's frame rate.
@@ -368,8 +374,12 @@ class FrameTimecode:
 
     def equal_framerate(self, fps) -> bool:
         """[DEPRECATED] Use :meth:`equal_frame_rate` instead."""
-        # TODO(https://scenedetect.com/issue/548): emit DeprecationWarning here once internal
-        # callers and downstream users have had a release to migrate to `equal_frame_rate`.
+        warnings.warn(
+            "`equal_framerate()` is deprecated and scheduled for removal in v0.9; "
+            "use `equal_frame_rate()` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self.equal_frame_rate(fps)
 
     @property

--- a/scenedetect/video_stream.py
+++ b/scenedetect/video_stream.py
@@ -66,7 +66,7 @@ class FrameRateUnavailable(VideoOpenFailure):
 
     def __init__(self):
         super().__init__(
-            "Unable to obtain video framerate! Specify `framerate` manually, or"
+            "Unable to obtain video framerate! Specify `frame_rate` manually, or"
             " re-encode/re-mux the video and try again."
         )
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -13,7 +13,6 @@
 
 These tests demonstrate common workflow patterns used when integrating the PySceneDetect API."""
 
-
 import pytest
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,6 +14,9 @@
 These tests demonstrate common workflow patterns used when integrating the PySceneDetect API."""
 
 
+import pytest
+
+
 def test_api_detect(test_video_file: str):
     """Demonstrate usage of the `detect()` function to process a complete video."""
     from scenedetect import ContentDetector, detect
@@ -73,15 +76,17 @@ def test_api_scene_manager_start_end_time(test_video_file: str):
 
 
 def test_api_open_video_framerate_legacy_alias(test_video_file: str):
-    """`open_video(framerate=...)` is the soft-deprecated alias for `frame_rate=` (issue #548).
+    """`open_video(framerate=...)` is the deprecated alias for `frame_rate=` (issue #548).
     Both forms must produce equivalent streams; when both are provided, `frame_rate` wins."""
     from scenedetect import open_video
 
-    legacy = open_video(test_video_file, framerate=30.0)
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        legacy = open_video(test_video_file, framerate=30.0)
     canonical = open_video(test_video_file, frame_rate=30.0)
     assert legacy.frame_rate == canonical.frame_rate
     # `frame_rate` takes precedence over `framerate` when both are provided.
-    both = open_video(test_video_file, frame_rate=30.0, framerate=24.0)
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        both = open_video(test_video_file, frame_rate=30.0, framerate=24.0)
     assert both.frame_rate == canonical.frame_rate
 
 

--- a/tests/test_backend_opencv.py
+++ b/tests/test_backend_opencv.py
@@ -18,6 +18,7 @@ For VideoStream tests that validate conformance, see test_video_stream.py.
 """
 
 import cv2
+import pytest
 
 from scenedetect import ContentDetector, SceneManager
 from scenedetect.backends.opencv import VideoCaptureAdapter, VideoStreamCv2
@@ -28,7 +29,7 @@ GROUND_TRUTH_CAPTURE_ADAPTER_CALLBACK_TEST = [180, 394]
 
 def test_open_image_sequence(test_image_sequence: str):
     """Test opening an image sequence. Currently, only VideoStreamCv2 supports this."""
-    sequence = VideoStreamCv2(test_image_sequence, framerate=25.0)
+    sequence = VideoStreamCv2(test_image_sequence, frame_rate=25.0)
     assert sequence.is_seekable
     assert sequence.frame_size[0] > 0 and sequence.frame_size[1] > 0
     assert sequence.duration is not None
@@ -51,6 +52,25 @@ def test_capture_adapter(test_movie_clip: str):
     scenes = scene_manager.get_scene_list()
     assert len(scenes) == len(GROUND_TRUTH_CAPTURE_ADAPTER_TEST)
     assert [start.frame_num for (start, _) in scenes] == GROUND_TRUTH_CAPTURE_ADAPTER_TEST
+
+
+def test_capture_adapter_framerate_legacy_alias(test_movie_clip: str):
+    """`framerate=` is the deprecated alias for `frame_rate=` on VideoCaptureAdapter."""
+    cap = cv2.VideoCapture(test_movie_clip)
+    assert cap.isOpened()
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        legacy = VideoCaptureAdapter(cap, framerate=30.0)
+
+    cap = cv2.VideoCapture(test_movie_clip)
+    assert cap.isOpened()
+    canonical = VideoCaptureAdapter(cap, frame_rate=30.0)
+    assert canonical.frame_rate == legacy.frame_rate
+
+    cap = cv2.VideoCapture(test_movie_clip)
+    assert cap.isOpened()
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        both = VideoCaptureAdapter(cap, frame_rate=30.0, framerate=24.0)
+    assert both.frame_rate == canonical.frame_rate
 
 
 def test_decode_failures_exposed(corrupt_video_file: str):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -335,38 +335,38 @@ def test_cli_detector_with_stats(tmp_path, detector_command: str):
     # and ensuring that we got some frames.
 
 
-def test_cli_framerate_legacy_alias():
-    """`--framerate` is the deprecated hidden alias for `-f/--frame-rate` (issue #548).
-    Both forms must be accepted; passing both should not error."""
-    # Canonical form.
+@pytest.mark.parametrize(
+    "option",
+    ["--frame-rate", "--framerate"],
+)
+def test_cli_frame_rate_aliases(option: str):
+    """Both long frame-rate spellings are accepted by the CLI."""
     exit_code, _ = invoke_cli(
-        ["-i", DEFAULT_VIDEO_PATH, "--frame-rate", "30.0", "time", "-s", "2s", "-d", "4s"]
+        ["-i", DEFAULT_VIDEO_PATH, option, "30.0", "time", "-s", "2s", "-d", "4s"]
     )
     assert exit_code == 0
-    # Legacy form.
-    with pytest.warns(DeprecationWarning, match="--frame-rate"):
-        exit_code, _ = invoke_cli(
-            ["-i", DEFAULT_VIDEO_PATH, "--framerate", "30.0", "time", "-s", "2s", "-d", "4s"]
-        )
+
+
+@pytest.mark.parametrize(
+    ("options", "succeeds"),
+    [
+        (["--frame-rate", "30.0", "--framerate", "0"], False),
+        (["--framerate", "0", "--frame-rate", "30.0"], True),
+    ],
+)
+def test_cli_frame_rate_aliases_last_value_wins(options: list[str], succeeds: bool):
+    """When a frame-rate option is repeated, only the last value is validated and used."""
+    exit_code, _ = invoke_cli(["-i", DEFAULT_VIDEO_PATH, *options, "time", "-s", "2s", "-d", "4s"])
+    assert (exit_code == 0) is succeeds
+
+
+def test_cli_framerate_alias_is_hidden():
+    """Help shows the primary frame-rate spellings but not the supported hidden alias."""
+    exit_code, output = invoke_cli(["--help"])
+
     assert exit_code == 0
-    # Both forms together: `--frame-rate` wins, a warning is logged but no error.
-    with pytest.warns(DeprecationWarning, match="--frame-rate"):
-        exit_code, _ = invoke_cli(
-            [
-                "-i",
-                DEFAULT_VIDEO_PATH,
-                "--frame-rate",
-                "30.0",
-                "--framerate",
-                "24.0",
-                "time",
-                "-s",
-                "2s",
-                "-d",
-                "4s",
-            ]
-        )
-    assert exit_code == 0
+    assert "-f, --frame-rate FPS" in output
+    assert "--framerate" not in output
 
 
 def test_cli_min_scene_len_accepts_all_timecode_forms(tmp_path: Path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -336,7 +336,7 @@ def test_cli_detector_with_stats(tmp_path, detector_command: str):
 
 
 def test_cli_framerate_legacy_alias():
-    """`--framerate` is the soft-deprecated hidden alias for `-f/--frame-rate` (issue #548).
+    """`--framerate` is the deprecated hidden alias for `-f/--frame-rate` (issue #548).
     Both forms must be accepted; passing both should not error."""
     # Canonical form.
     exit_code, _ = invoke_cli(
@@ -344,26 +344,28 @@ def test_cli_framerate_legacy_alias():
     )
     assert exit_code == 0
     # Legacy form.
-    exit_code, _ = invoke_cli(
-        ["-i", DEFAULT_VIDEO_PATH, "--framerate", "30.0", "time", "-s", "2s", "-d", "4s"]
-    )
+    with pytest.warns(DeprecationWarning, match="--frame-rate"):
+        exit_code, _ = invoke_cli(
+            ["-i", DEFAULT_VIDEO_PATH, "--framerate", "30.0", "time", "-s", "2s", "-d", "4s"]
+        )
     assert exit_code == 0
     # Both forms together: `--frame-rate` wins, a warning is logged but no error.
-    exit_code, _ = invoke_cli(
-        [
-            "-i",
-            DEFAULT_VIDEO_PATH,
-            "--frame-rate",
-            "30.0",
-            "--framerate",
-            "24.0",
-            "time",
-            "-s",
-            "2s",
-            "-d",
-            "4s",
-        ]
-    )
+    with pytest.warns(DeprecationWarning, match="--frame-rate"):
+        exit_code, _ = invoke_cli(
+            [
+                "-i",
+                DEFAULT_VIDEO_PATH,
+                "--frame-rate",
+                "30.0",
+                "--framerate",
+                "24.0",
+                "time",
+                "-s",
+                "2s",
+                "-d",
+                "4s",
+            ]
+        )
     assert exit_code == 0
 
 

--- a/tests/test_timecode.py
+++ b/tests/test_timecode.py
@@ -73,12 +73,16 @@ def test_frame_rate_property():
     tc = FrameTimecode(timecode=0, fps=30.0)
     assert tc.frame_rate == Fraction(30, 1)
     assert isinstance(tc.frame_rate, Fraction)
-    assert tc.framerate == 30.0
-    assert isinstance(tc.framerate, float)
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        legacy_frame_rate = tc.framerate
+
+    assert legacy_frame_rate == 30.0
+    assert isinstance(legacy_frame_rate, float)
     # Constructed directly from a Fraction (the exact form for NTSC rates).
     tc = FrameTimecode(timecode=0, fps=Fraction(30000, 1001))
     assert tc.frame_rate == Fraction(30000, 1001)
-    assert tc.framerate == pytest.approx(float(Fraction(30000, 1001)))
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        assert tc.framerate == pytest.approx(float(Fraction(30000, 1001)))
     tc = FrameTimecode(timecode=0, fps=Fraction(24000, 1001))
     assert tc.frame_rate == Fraction(24000, 1001)
     # time_base equals 1 / frame_rate for CFR sources.
@@ -108,17 +112,21 @@ def test_frame_num_and_frame_rate_are_read_only():
 
 
 def test_equal_frame_rate_legacy_alias():
-    """`equal_framerate()` is the soft-deprecated alias for `equal_frame_rate()` (issue #548).
+    """`equal_framerate()` is the deprecated alias for `equal_frame_rate()` (issue #548).
     Both forms should produce identical results for every accepted operand type."""
     tc = FrameTimecode(timecode=0, fps=30.0)
     # float, Fraction, FrameTimecode operands.
     other_tc = FrameTimecode(timecode=0, fps=30.0)
     for other in (30.0, Fraction(30, 1), other_tc):
-        assert tc.equal_frame_rate(other) == tc.equal_framerate(other)
-        assert tc.equal_frame_rate(other) is True
+        expected = tc.equal_frame_rate(other)
+        with pytest.warns(DeprecationWarning, match="equal_frame_rate"):
+            actual = tc.equal_framerate(other)
+        assert actual == expected
+        assert actual is True
     # Mismatched rate.
     assert tc.equal_frame_rate(24.0) is False
-    assert tc.equal_framerate(24.0) is False
+    with pytest.warns(DeprecationWarning, match="equal_frame_rate"):
+        assert tc.equal_framerate(24.0) is False
 
 
 def test_timecode_numeric():
@@ -555,3 +563,15 @@ def test_min_scene_len_accepts_timecode_like():
     # ContentDetector: same.
     ContentDetector(min_scene_len=FrameTimecode(timecode=15, fps=30.0))
     ContentDetector(min_scene_len=Timecode(pts=500, time_base=Fraction(1, 1000)))
+
+
+def test_get_framerate():
+    """`get_framerate()` emits one warning and preserves its legacy float return value."""
+    tc = FrameTimecode(timecode=0, fps=30.0)
+
+    with pytest.warns(DeprecationWarning, match="frame_rate") as warning_info:
+        frame_rate = tc.get_framerate()
+
+    assert len(warning_info) == 1
+    assert frame_rate == 30.0
+    assert isinstance(frame_rate, float)

--- a/tests/test_video_stream.py
+++ b/tests/test_video_stream.py
@@ -359,14 +359,16 @@ def test_invalid_path(vs_type: ty.Callable[..., VideoStream]):
 
 
 def test_framerate_legacy_alias(vs_type: ty.Callable[..., VideoStream], auto_close):
-    """`framerate=` is the soft-deprecated alias for `frame_rate=` (issue #548). All backends
+    """`framerate=` is the deprecated alias for `frame_rate=` (issue #548). All backends
     must accept both forms and produce the same `frame_rate`."""
     path = get_absolute_path("resources/goldeneye.mp4")
-    legacy = auto_close(vs_type(path, framerate=30.0))
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        legacy = auto_close(vs_type(path, framerate=30.0))
     canonical = auto_close(vs_type(path, frame_rate=30.0))
     assert legacy.frame_rate == canonical.frame_rate
     # When both are provided, `frame_rate` wins (legacy is ignored).
-    both = auto_close(vs_type(path, frame_rate=30.0, framerate=24.0))
+    with pytest.warns(DeprecationWarning, match="frame_rate"):
+        both = auto_close(vs_type(path, frame_rate=30.0, framerate=24.0))
     assert both.frame_rate == canonical.frame_rate
 
 


### PR DESCRIPTION
Closes #548

## Summary

* Emit `DeprecationWarning` for deprecated `framerate` aliases across `FrameTimecode`, `open_video()`, video backends, and the CLI.
* Preserve existing compatibility behavior, including `frame_rate` taking precedence when both forms are provided.
* Add/update tests for the deprecated aliases, including `VideoCaptureAdapter`.
* Update `get_framerate()` to direct users to `frame_rate` without emitting duplicate warnings.

## Testing

* Added warning assertions for deprecated aliases.
* Verified canonical `frame_rate` usage remains warning-free.
* Verified legacy aliases continue to work while emitting `DeprecationWarning`.
