### PR TITLE
Make frame-rate CLI options aliases

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -61,13 +61,9 @@ Options
 
   Stats file (.csv) to write frame metrics. Existing files will be overwritten. Used for tuning detection parameters and data analysis.
 
-.. option:: -f FPS, --frame-rate FPS
+.. option:: -f FPS, --framerate FPS, --frame-rate FPS
 
   Override frame rate with value as frames/sec.
-
-.. option:: --framerate FPS
-
-  Alias of :option:`-f/--frame-rate <-f>`.
 
 .. option:: -m TIMECODE, --min-scene-len TIMECODE
 

--- a/scenedetect/_cli/__init__.py
+++ b/scenedetect/_cli/__init__.py
@@ -230,22 +230,13 @@ Global options (e.g. -i/--input, -c/--config) must be specified before any comma
 )
 @click.option(
     "--frame-rate",
+    "--framerate",
     "-f",
     "frame_rate",
     metavar="FPS",
     type=click.FLOAT,
     default=None,
     help="Override frame rate with value as frames/sec.",
-)
-# Keep --framerate separate so Click can hide it while mapping both spellings to frame_rate.
-@click.option(
-    "--framerate",
-    "frame_rate",
-    metavar="FPS",
-    type=click.FLOAT,
-    default=None,
-    hidden=True,
-    help="Alias of -f/--frame-rate.",
 )
 @click.option(
     "--min-scene-len",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -337,10 +337,10 @@ def test_cli_detector_with_stats(tmp_path, detector_command: str):
 
 @pytest.mark.parametrize(
     "option",
-    ["--frame-rate", "--framerate"],
+    ["--frame-rate", "--framerate", "-f"],
 )
 def test_cli_frame_rate_aliases(option: str):
-    """Both long frame-rate spellings are accepted by the CLI."""
+    """All frame-rate aliases are accepted by the CLI."""
     exit_code, _ = invoke_cli(
         ["-i", DEFAULT_VIDEO_PATH, option, "30.0", "time", "-s", "2s", "-d", "4s"]
     )
@@ -360,13 +360,12 @@ def test_cli_frame_rate_aliases_last_value_wins(options: list[str], succeeds: bo
     assert (exit_code == 0) is succeeds
 
 
-def test_cli_framerate_alias_is_hidden():
-    """Help shows the primary frame-rate spellings but not the supported hidden alias."""
+def test_cli_framerate_alias_is_visible():
+    """Help shows all frame-rate aliases as one option."""
     exit_code, output = invoke_cli(["--help"])
 
     assert exit_code == 0
-    assert "-f, --frame-rate FPS" in output
-    assert "--framerate" not in output
+    assert "-f, --frame-rate, --framerate FPS" in output
 
 
 def test_cli_min_scene_len_accepts_all_timecode_forms(tmp_path: Path):


### PR DESCRIPTION
Closes #548 

Makes `-f`, `--frame-rate`, and `--framerate` aliases of the same CLI option. All forms now appear in help and documentation. When multiple forms are used, Click uses the last value.

Updates the related CLI tests.